### PR TITLE
Refactor Square client instantiation

### DIFF
--- a/checkout_process.php
+++ b/checkout_process.php
@@ -3,7 +3,7 @@ require 'includes/requirements.php';
 require 'includes/auth.php';
 require 'includes/db.php';
 require 'includes/url.php';
-require 'includes/square.php';
+$client = require 'includes/square.php';
 
 $token = $_POST['token'] ?? '';
 $listing_id = isset($_POST['listing_id']) ? intval($_POST['listing_id']) : 0;
@@ -30,7 +30,7 @@ use Square\Exceptions\ApiException;
 use Square\Models\CreatePaymentRequest;
 use Square\Models\Money;
 
-$paymentsApi = $square->getPaymentsApi();
+$paymentsApi = $client->getPaymentsApi();
 
 $money = new Money();
 $money->setAmount($amount);

--- a/includes/square.php
+++ b/includes/square.php
@@ -37,9 +37,12 @@ if (!class_exists('\Square\SquareClient')) {
 $config = require __DIR__ . '/../config.square.php';
 $env = (strtolower(trim($config['SQUARE_ENV'] ?? 'sandbox')) === 'production') ? 'production' : 'sandbox';
 
-$client = new \Square\SquareClient([
-  'accessToken' => (string)($config['SQUARE_ACCESS_TOKEN'] ?? ''),
-  'environment' => $env, // 'sandbox' | 'production'
-]);
+$client = new \Square\SquareClient(
+  $config['SQUARE_ACCESS_TOKEN'] ?? '',
+  $env, // 'sandbox' or 'production'
+  [
+    // Optional SDK options, e.g. 'timeout' => 30
+  ]
+);
 
 return $client;


### PR DESCRIPTION
## Summary
- use positional parameters to instantiate Square\SquareClient
- capture and use Square client in checkout process

## Testing
- `php -l includes/square.php`
- `php -l checkout_process.php`


------
https://chatgpt.com/codex/tasks/task_e_68b590843e4c832ba0df580d3765d86f