### PR TITLE
refactor: instantiate Square client directly

### DIFF
--- a/checkout.php
+++ b/checkout.php
@@ -1,4 +1,5 @@
 <?php
+$squareConfig = require __DIR__ . '/includes/square-config.php';
 $client = require __DIR__ . '/includes/square.php';
 // $paymentsApi = $client->getPaymentsApi();
 

--- a/checkout_process.php
+++ b/checkout_process.php
@@ -1,4 +1,5 @@
 <?php
+$squareConfig = require __DIR__ . '/includes/square-config.php';
 require 'includes/requirements.php';
 require 'includes/auth.php';
 require 'includes/db.php';

--- a/includes/square-config.php
+++ b/includes/square-config.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Square application configuration helper.
+ *
+ * Loads application ID, location ID, and environment from the main config
+ * file if available or from environment variables as a fallback.
+ */
+
+$configPath = __DIR__ . '/../config.php';
+if (file_exists($configPath)) {
+    $config = require $configPath;
+    $applicationId = $config['square_application_id'] ?? getenv('SQUARE_APPLICATION_ID') ?: 'YOUR_APPLICATION_ID';
+    $locationId    = $config['square_location_id'] ?? getenv('SQUARE_LOCATION_ID') ?: 'YOUR_LOCATION_ID';
+    $environment   = $config['square_environment'] ?? getenv('SQUARE_ENVIRONMENT') ?: 'sandbox';
+} else {
+    $applicationId = getenv('SQUARE_APPLICATION_ID') ?: 'YOUR_APPLICATION_ID';
+    $locationId    = getenv('SQUARE_LOCATION_ID') ?: 'YOUR_LOCATION_ID';
+    $environment   = getenv('SQUARE_ENVIRONMENT') ?: 'sandbox';
+}
+
+return [
+    'application_id' => $applicationId,
+    'location_id'    => $locationId,
+    'environment'    => strtolower($environment) === 'production' ? 'production' : 'sandbox',
+];

--- a/includes/square.php
+++ b/includes/square.php
@@ -30,15 +30,24 @@ if (is_dir($squareSrc)) {
   $loader->addPsr4('Square\\', $squareSrc, true);
 }
 
-if (!class_exists('\Square\SquareClient')) {
+if (!class_exists('\\Square\\SquareClient')) {
   throw new RuntimeException("Square SDK not autoloadable after PSR-4 registration");
 }
 
-$config = require __DIR__ . '/../config.square.php';
-$env = (strtolower(trim($config['SQUARE_ENV'] ?? 'sandbox')) === 'production') ? 'production' : 'sandbox';
+// Load Square configuration constants
+require __DIR__ . '/../config.square.php';
+
+$token = SQUARE_ACCESS_TOKEN;
+if ($token === '') {
+  throw new RuntimeException('SQUARE_ACCESS_TOKEN is not defined or empty');
+}
+
+$env = defined('SQUARE_ENV') && strtolower(SQUARE_ENV) === 'production'
+  ? 'production'
+  : 'sandbox';
 
 $client = new \Square\SquareClient(
-  $config['SQUARE_ACCESS_TOKEN'] ?? '',
+  $token,
   $env, // 'sandbox' or 'production'
   [
     // Optional SDK options, e.g. 'timeout' => 30


### PR DESCRIPTION
## Summary
- replace builder pattern with direct `Square\SquareClient` constructor
- read Square credentials from `config.square.php` constants
- centralize Square web config in `includes/square-config.php` and use it in checkout scripts

## Testing
- `php -l includes/square-config.php`
- `php -l checkout.php`
- `php -l checkout_process.php`


------
https://chatgpt.com/codex/tasks/task_e_68b78286d094832b9caf893ac7296565