### PR TITLE
Refactor Square payment client usage

### DIFF
--- a/checkout_process.php
+++ b/checkout_process.php
@@ -31,8 +31,6 @@ use Square\Exceptions\ApiException;
 use Square\Models\CreatePaymentRequest;
 use Square\Models\Money;
 
-$paymentsApi = $client->getPaymentsApi();
-
 $money = new Money();
 $money->setAmount($amount);
 $money->setCurrency('USD');
@@ -42,7 +40,7 @@ $paymentRequest->setAmountMoney($money);
 $paymentRequest->setLocationId($squareConfig['location_id']);
 
 try {
-    $apiResponse = $paymentsApi->createPayment($paymentRequest);
+    $apiResponse = $client->payments->createPayment($paymentRequest);
     $result = $apiResponse->getResult();
     $status = $result->getPayment()->getStatus();
     $paymentId = $result->getPayment()->getId();


### PR DESCRIPTION
## Summary
- remove deprecated `getPaymentsApi` client call
- create payments via new `$client->payments` interface
- confirm no other `getPaymentsApi` usages

## Testing
- `php -l checkout_process.php`

------
https://chatgpt.com/codex/tasks/task_e_68b7a6522b70832bbe54cba116247104