### PR TITLE
refactor: update Square SDK imports

### DIFF
--- a/checkout_process.php
+++ b/checkout_process.php
@@ -1,4 +1,8 @@
 <?php
+use Square\Payments\Requests\CreatePaymentRequest;
+use Square\Types\Money;
+use Square\Exceptions\SquareApiException;
+
 $client = require __DIR__ . '/includes/square.php';
 $squareConfig = require __DIR__ . '/includes/square-config.php';
 require 'includes/requirements.php';
@@ -27,10 +31,6 @@ $stmt->close();
 
 $amount = (int)round($price * 100);
 
-use Square\Exceptions\ApiException;
-use Square\Models\CreatePaymentRequest;
-use Square\Models\Money;
-
 $money = new Money();
 $money->setAmount($amount);
 $money->setCurrency('USD');
@@ -44,7 +44,7 @@ try {
     $result = $apiResponse->getResult();
     $status = $result->getPayment()->getStatus();
     $paymentId = $result->getPayment()->getId();
-} catch (ApiException $e) {
+} catch (SquareApiException $e) {
     $status = 'FAILED';
     $paymentId = null;
 }


### PR DESCRIPTION
## Summary
- move Square SDK use statements to top of `checkout_process.php`
- replace legacy namespaces with `Payments\Requests\CreatePaymentRequest`, `Types\Money`, and `Exceptions\SquareApiException`
- handle `SquareApiException` in checkout payment flow

## Testing
- `php -l checkout_process.php`
- `php -r "require 'vendor/autoload.php'; \$m=new \\Square\\Types\\Money(); \$m->setAmount(123); \$m->setCurrency('USD'); echo 'Money ok';"`

------
https://chatgpt.com/codex/tasks/task_e_68b7a9286880832bacd18c089c55fc38