### PR TITLE
Ensure consistent strict type headers

### DIFF
--- a/_debug_bootstrap.php
+++ b/_debug_bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**

--- a/_health.php
+++ b/_health.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 require __DIR__ . '/_debug_bootstrap.php';
 
 echo "<pre>";

--- a/checkout_process.php
+++ b/checkout_process.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 require __DIR__ . '/_debug_bootstrap.php';

--- a/includes/square.php
+++ b/includes/square.php
@@ -1,5 +1,8 @@
 <?php
+
 declare(strict_types=1);
+
+require __DIR__ . '/../_debug_bootstrap.php';
 
 require __DIR__ . '/../vendor/autoload.php';
 $config = require __DIR__ . '/../config.php';


### PR DESCRIPTION
## Summary
- standardize header ordering for PHP files using strict types
- include debug bootstrap after declare where needed

## Testing
- `php -l checkout_process.php _health.php includes/square.php _debug_bootstrap.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7b27d3af4832b93ad9b1036cb0c8d