### PR TITLE
feat: enhance messaging UI and language toggle

### DIFF
--- a/assets/flags/es.svg
+++ b/assets/flags/es.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="3" height="2" fill="#aa151b"/>
+  <rect y="0.5" width="3" height="1" fill="#f1bf00"/>
+</svg>

--- a/assets/language-toggle.js
+++ b/assets/language-toggle.js
@@ -1,0 +1,61 @@
+const translations = {
+  en: {
+    home: 'Home',
+    about: 'About',
+    help: 'Help/FAQ',
+    dashboard: 'Dashboard',
+    notifications: 'Notifications',
+    messages: 'Messages',
+    logout: 'Logout',
+    login: 'Login',
+    register: 'Register',
+    search: 'Search...',
+    send: 'Send',
+    conversationWith: 'Conversation with'
+  },
+  es: {
+    home: 'Inicio',
+    about: 'Acerca de',
+    help: 'Ayuda/FAQ',
+    dashboard: 'Panel',
+    notifications: 'Notificaciones',
+    messages: 'Mensajes',
+    logout: 'Salir',
+    login: 'Iniciar sesión',
+    register: 'Registrarse',
+    search: 'Buscar...',
+    send: 'Enviar',
+    conversationWith: 'Conversación con'
+  }
+};
+
+let lang = localStorage.getItem('lang') || 'en';
+const flagImg = document.querySelector('#language-toggle img');
+
+function applyTranslations() {
+  document.documentElement.lang = lang;
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.dataset.i18n;
+    if (translations[lang][key]) {
+      el.textContent = translations[lang][key];
+    }
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    const key = el.dataset.i18nPlaceholder;
+    if (translations[lang][key]) {
+      el.placeholder = translations[lang][key];
+    }
+  });
+  if (flagImg) {
+    flagImg.src = `/assets/flags/${lang}.svg`;
+    flagImg.alt = lang === 'en' ? 'English' : 'Español';
+  }
+}
+
+applyTranslations();
+
+document.getElementById('language-toggle').addEventListener('click', () => {
+  lang = lang === 'en' ? 'es' : 'en';
+  localStorage.setItem('lang', lang);
+  applyTranslations();
+});

--- a/assets/message-tools.js
+++ b/assets/message-tools.js
@@ -1,0 +1,25 @@
+const textarea = document.querySelector('.message-form textarea');
+if (textarea) {
+  document.querySelectorAll('.message-tools button').forEach(btn => {
+    const format = btn.dataset.format;
+    const insert = btn.dataset.insert;
+    btn.addEventListener('click', () => {
+      const start = textarea.selectionStart;
+      const end = textarea.selectionEnd;
+      const value = textarea.value;
+      if (format === 'bold') {
+        textarea.value = value.slice(0, start) + '**' + value.slice(start, end) + '**' + value.slice(end);
+        textarea.selectionStart = start + 2;
+        textarea.selectionEnd = end + 2;
+      } else if (format === 'italic') {
+        textarea.value = value.slice(0, start) + '*' + value.slice(start, end) + '*' + value.slice(end);
+        textarea.selectionStart = start + 1;
+        textarea.selectionEnd = end + 1;
+      } else if (insert) {
+        textarea.value = value.slice(0, start) + insert + value.slice(end);
+        textarea.selectionStart = textarea.selectionEnd = start + insert.length;
+      }
+      textarea.focus();
+    });
+  });
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -425,6 +425,13 @@ footer:hover {
   justify-content: center;
 }
 
+.site-search input {
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--fg);
+  border-radius: 4px;
+  color: var(--fg);
+}
+
 .logo-img {
   max-width: 60px;
   height: auto;
@@ -438,6 +445,13 @@ footer:hover {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.header-left ul,
+.header-right ul {
+  border: 1px solid var(--fg);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
 }
 
 .site-nav a {
@@ -941,12 +955,43 @@ body.nav-open footer {
 
 .message {
   margin-bottom: 0.5rem;
+  border: 1px solid var(--fg);
+  padding: 0.5rem;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.message-sender {
+  color: var(--accent);
+  font-weight: bold;
+}
+
+.message-body {
+  color: var(--fg);
+  margin-top: 0.25rem;
+}
+
+.message-time {
+  color: #aaa;
+  font-size: 0.8rem;
+  text-align: right;
+  margin-top: 0.25rem;
 }
 
 .message-form textarea {
   width: 100%;
   height: 80px;
   margin-bottom: 0.5rem;
+}
+
+.message-tools {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.message-tools button {
+  padding: 0.25rem 0.5rem;
 }
 
 /* Forum posts */

--- a/includes/header.php
+++ b/includes/header.php
@@ -42,24 +42,24 @@ if (!empty($_SESSION['user_id'])) {
       <img class="logo-img" src="/assets/logo.png" alt="SkuzE Logo">
     </a>
     <ul>
-      <li><a href="/index.php">Home</a></li>
-      <li><a href="/about.php">About</a></li>
-      <li><a href="/help.php">Help/FAQ</a></li>
+      <li><a href="/index.php" data-i18n="home">Home</a></li>
+      <li><a href="/about.php" data-i18n="about">About</a></li>
+      <li><a href="/help.php" data-i18n="help">Help/FAQ</a></li>
     </ul>
   </nav>
   <form class="site-search header-center" action="/search.php" method="get">
-    <input type="text" name="q" placeholder="Search..." value="<?= htmlspecialchars($_GET['q'] ?? '') ?>">
+    <input type="text" name="q" placeholder="Search..." data-i18n-placeholder="search" value="<?= htmlspecialchars($_GET['q'] ?? '') ?>">
   </form>
   <nav class="site-nav header-right">
     <ul>
 <?php if (empty($_SESSION['user_id'])): ?>
-      <li><a href="/login.php">Login</a></li>
-      <li><a href="/register.php">Register</a></li>
+      <li><a href="/login.php" data-i18n="login">Login</a></li>
+      <li><a href="/register.php" data-i18n="register">Register</a></li>
 <?php else: ?>
-      <li><a href="/dashboard.php">Dashboard</a></li>
-      <li><a href="/notifications.php">Notifications<?php if (!empty($unread_notifications)): ?><span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a></li>
-      <li><a href="/messages.php">Messages<?php if (!empty($unread_messages)): ?><span class="badge"><?= $unread_messages ?></span><?php endif; ?></a></li>
-      <li><a href="/logout.php">Logout</a></li>
+      <li><a href="/dashboard.php" data-i18n="dashboard">Dashboard</a></li>
+      <li><a href="/notifications.php" data-i18n="notifications">Notifications<?php if (!empty($unread_notifications)): ?><span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a></li>
+      <li><a href="/messages.php" data-i18n="messages">Messages<?php if (!empty($unread_messages)): ?><span class="badge"><?= $unread_messages ?></span><?php endif; ?></a></li>
+      <li><a href="/logout.php" data-i18n="logout">Logout</a></li>
       <li class="user-info"><?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?></li>
 <?php endif; ?>
       <li class="cart-link">
@@ -91,3 +91,4 @@ if (!empty($_SESSION['user_id'])) {
 </div>
 <script type="module" src="/assets/admin-pattern.js" defer></script>
 <script type="module" src="/assets/theme-toggle.js" defer></script>
+<script type="module" src="/assets/language-toggle.js" defer></script>

--- a/message-thread.php
+++ b/message-thread.php
@@ -39,6 +39,13 @@ $update->bind_param('ii', $other_id, $user_id);
 $update->execute();
 $update->close();
 
+function format_message($text) {
+  $text = htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+  $text = preg_replace('/\*\*(.*?)\*\*/s', '<strong>$1</strong>', $text);
+  $text = preg_replace('/\*(.*?)\*/s', '<em>$1</em>', $text);
+  return nl2br($text);
+}
+
 $stmt = $conn->prepare('SELECT m.sender_id, m.recipient_id, m.body, m.created_at, u.username AS sender_name
   FROM messages m JOIN users u ON m.sender_id = u.id
   WHERE (m.sender_id = ? AND m.recipient_id = ?) OR (m.sender_id = ? AND m.recipient_id = ?)
@@ -55,20 +62,27 @@ $stmt->close();
 <body>
   <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
-  <h2>Conversation with <?= htmlspecialchars($other_username) ?></h2>
+  <h2><span data-i18n="conversationWith">Conversation with</span> <?= htmlspecialchars($other_username) ?></h2>
   <div class="message-thread">
     <?php foreach ($messages as $msg): ?>
       <div class="message">
-        <strong><?= htmlspecialchars($msg['sender_name']) ?>:</strong>
-        <span><?= nl2br(htmlspecialchars($msg['body'])) ?></span>
-        <em><?= htmlspecialchars($msg['created_at']) ?></em>
+        <div class="message-sender"><?= htmlspecialchars($msg['sender_name']) ?>:</div>
+        <div class="message-body"><?= format_message($msg['body']) ?></div>
+        <div class="message-time"><?= htmlspecialchars($msg['created_at']) ?></div>
       </div>
     <?php endforeach; ?>
   </div>
   <form method="post" class="message-form">
+    <div class="message-tools">
+      <button type="button" data-format="bold"><strong>B</strong></button>
+      <button type="button" data-format="italic"><em>I</em></button>
+      <button type="button" data-insert="😊">😊</button>
+      <button type="button" data-insert="( ͡° ͜ʖ ͡°)">( ͡° ͜ʖ ͡°)</button>
+    </div>
     <textarea name="body" required></textarea>
-    <button type="submit" class="btn">Send</button>
+    <button type="submit" class="btn" data-i18n="send">Send</button>
   </form>
+  <script type="module" src="/assets/message-tools.js"></script>
   <?php include 'includes/footer.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- color-code message threads with sender, body, and timestamp boxes
- add bold, italic, emoji, and ASCII quick inserts to message composer
- enable simple language switching and style header search/navigation groups

## Testing
- `php -l message-thread.php includes/header.php`
- `node --check assets/language-toggle.js && echo "language ok"`
- `node --check assets/message-tools.js && echo "tools ok"`


------
https://chatgpt.com/codex/tasks/task_e_68b7c68f8ce8832bb5c38a0a46d5f965