### PR TITLE
Organize dashboard navigation and add notification icons

### DIFF
--- a/admin/view.php
+++ b/admin/view.php
@@ -3,6 +3,7 @@ require '../includes/auth.php';
 require '../includes/db.php';
 require '../includes/csrf.php';
 require '../includes/user.php';
+require '../includes/notifications.php';
 
 if (!$_SESSION['is_admin']) {
   header("Location: ../dashboard.php");
@@ -48,6 +49,9 @@ $online_status = $is_online ? "<span style='color:green;'>Online</span>" : "<spa
         $update->bind_param("ssi", $status, $note, $id);
         if (!$update->execute()) {
           error_log('Execute failed: ' . $update->error);
+        } else {
+          $msg = notification_message('service_status', ['status' => $status]);
+          create_notification($conn, $data['user_id'], 'service_status', $msg);
         }
         $update->close();
       }

--- a/assets/bell.svg
+++ b/assets/bell.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+  <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+</svg>

--- a/assets/envelope.svg
+++ b/assets/envelope.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="4" width="20" height="16" rx="2" ry="2"/>
+  <polyline points="22 6 12 13 2 6"/>
+</svg>

--- a/assets/style.css
+++ b/assets/style.css
@@ -72,6 +72,11 @@ body {
   padding-bottom: 4rem;
 }
 
+body.site-frame {
+  outline: 4px var(--fg) var(--site-border, solid);
+  outline-offset: -4px;
+}
+
 .vap-lines {
   position: relative;
 }
@@ -413,6 +418,10 @@ footer:hover {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding: 0.25rem 0.5rem;
+  background: rgba(0, 0, 0, 0.3);
+  background: color-mix(in srgb, var(--bg) 60%, transparent);
+  border-radius: 4px;
 }
 
 .header-left,
@@ -425,10 +434,16 @@ footer:hover {
   justify-content: center;
 }
 
-.site-search input {
+.search-container {
   background: rgba(0, 0, 0, 0.5);
   border: 1px solid var(--fg);
   border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+}
+
+.site-search input {
+  background: transparent;
+  border: none;
   color: var(--fg);
 }
 
@@ -464,6 +479,20 @@ footer:hover {
   transform: perspective(300px) translateZ(0);
   transition: background 0.2s, transform 0.1s, box-shadow 0.1s;
   text-transform: uppercase;
+  position: relative;
+}
+
+.site-nav a img {
+  display: block;
+  width: 24px;
+  height: 24px;
+}
+
+.site-nav a .badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  margin-left: 0;
 }
 
 .site-nav a:hover {
@@ -545,6 +574,34 @@ form button:active {
   box-shadow: inset 0 calc(var(--btn-depth) / 3) 0 rgba(0, 0, 0, 0.4);
 }
 
+.nav-sections {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.nav-section {
+  flex: 1 1 200px;
+}
+
+.nav-section h3 {
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.nav-section .nav-links {
+  flex-direction: column;
+  align-items: center;
+}
+
+@media (min-width: 600px) {
+  .nav-section .nav-links {
+    flex-direction: row;
+  }
+}
+
 .nav-links {
   display: flex;
   flex-wrap: wrap;
@@ -614,14 +671,16 @@ form button:active {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
 }
 
-#theme-modal .theme-options {
+#theme-modal .theme-options,
+#theme-modal .border-options {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   margin-bottom: 1rem;
 }
 
-#theme-modal .theme-options .btn.active {
+#theme-modal .theme-options .btn.active,
+#theme-modal .border-options .btn.active {
   transform: perspective(400px) translateZ(calc(var(--btn-depth) / 3));
   box-shadow: inset 0 -2px 0 rgba(255, 255, 255, 0.2),
     inset 0 2px 0 rgba(0, 0, 0, 0.4),

--- a/assets/themes.json
+++ b/assets/themes.json
@@ -53,5 +53,12 @@
       "--accent": "#4caf50",
       "--gradient": "linear-gradient(135deg, #2e3d2f 0%, #1b2c20 100%)"
     }
+  },
+  "borders": {
+    "/": "dashed",
+    "*": "dotted",
+    "-": "solid",
+    ":": "double",
+    "|": "ridge"
   }
 }

--- a/cart.php
+++ b/cart.php
@@ -96,7 +96,9 @@ $grand_total = $total + $tax + $shipping;
     <p><strong>Total: $<?= number_format($grand_total, 2) ?></strong></p>
     <button type="submit">Update Cart</button>
 </form>
-<p><a href="checkout.php">Proceed to Checkout</a></p>
+<form action="checkout.php" method="get">
+    <button type="submit">Proceed to Checkout</button>
+</form>
 <?php endif; ?>
 </body>
 </html>

--- a/compose-message.php
+++ b/compose-message.php
@@ -2,6 +2,7 @@
 require 'includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
+require 'includes/notifications.php';
 
 $user_id = $_SESSION['user_id'];
 $error = '';
@@ -23,6 +24,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $insert->bind_param('iis', $user_id, $recipient_id, $body);
         $insert->execute();
         $insert->close();
+        if (!empty($_SESSION['is_admin'])) {
+          $msg = notification_message('admin_message');
+          create_notification($conn, $recipient_id, 'admin_message', $msg);
+        }
         header("Location: message-thread.php?user=$recipient_id");
         exit;
       }

--- a/dashboard.php
+++ b/dashboard.php
@@ -21,14 +21,7 @@ if ($stmt === false) {
   }
 }
 $vip_active = $vip && (!$vip_expires || strtotime($vip_expires) > time());
-$unread_messages = 0;
-if ($stmt = $conn->prepare('SELECT COUNT(*) FROM messages WHERE recipient_id = ? AND read_at IS NULL')) {
-  $stmt->bind_param('i', $id);
-  $stmt->execute();
-  $stmt->bind_result($unread_messages);
-  $stmt->fetch();
-  $stmt->close();
-}
+$unread_messages = count_unread_messages($conn, $id);
 $unread_notifications = count_unread_notifications($conn, $id);
 ?>
 <?php require 'includes/layout.php'; ?>
@@ -48,17 +41,32 @@ $unread_notifications = count_unread_notifications($conn, $id);
   <?php elseif ($vip): ?>
     <p class="notice">Your VIP membership expired on <?= htmlspecialchars($vip_expires) ?>. <a href="vip.php">Renew now</a>.</p>
   <?php endif; ?>
-  <div class="nav-links">
-    <a class="btn" role="button" href="services.php">Start a Service Request</a>
-    <a class="btn" role="button" href="my-requests.php">View My Service Requests</a>
-    <a class="btn" role="button" href="my-listings.php">Manage My Listings</a>
-    <a class="btn" role="button" href="notifications.php">Notifications<?php if (!empty($unread_notifications)): ?> <span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a>
-    <a class="btn" role="button" href="messages.php">Messages<?php if (!empty($unread_messages)): ?> <span class="badge"><?= $unread_messages ?></span><?php endif; ?></a>
-    <?php if (!empty($_SESSION['is_admin'])): ?>
-      <a class="btn" role="button" href="/admin/index.php">Admin Panel</a>
-    <?php endif; ?>
-    <a class="btn" role="button" href="profile.php">Edit Profile</a>
-    <a class="btn" role="button" href="logout.php">Logout</a>
+  <div class="nav-sections">
+    <div class="nav-section">
+      <h3>Service Requests</h3>
+      <div class="nav-links">
+        <a class="btn" role="button" href="services.php">Start a Service Request</a>
+        <a class="btn" role="button" href="my-requests.php">View My Service Requests</a>
+        <a class="btn" role="button" href="my-listings.php">Manage My Listings</a>
+      </div>
+    </div>
+    <div class="nav-section">
+      <h3>Communications</h3>
+      <div class="nav-links">
+        <a class="btn" role="button" href="notifications.php">Notifications<?php if (!empty($unread_notifications)): ?> <span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a>
+        <a class="btn" role="button" href="messages.php">Messages<?php if (!empty($unread_messages)): ?> <span class="badge"><?= $unread_messages ?></span><?php endif; ?></a>
+      </div>
+    </div>
+    <div class="nav-section">
+      <h3>Account</h3>
+      <div class="nav-links">
+        <?php if (!empty($_SESSION['is_admin'])): ?>
+          <a class="btn" role="button" href="/admin/index.php">Admin Panel</a>
+        <?php endif; ?>
+        <a class="btn" role="button" href="profile.php">Edit Profile</a>
+        <a class="btn" role="button" href="logout.php">Logout</a>
+      </div>
+    </div>
   </div>
   <?php include 'includes/footer.php'; ?>
 </body>


### PR DESCRIPTION
## Summary
- Split dashboard navigation into Service Requests, Communications, and Account sections with group headings
- Add bell and envelope icons to header with unread badges and accessible labels
- Trigger notifications for service status changes, shipping updates, and admin messages
- Style header badges for better visibility and announce unread counts
- Introduce selectable site border styles via `--site-border` variable and `.site-frame` class
- Link cart icon to the cart page and add a checkout button after reviewing items
- Wrap site search form in a padded container that matches the header color scheme
- Centralize template messages and send service and shipping notifications using `notification_message()`
- Give header segments theme-aware, semi-transparent backgrounds with padding for visual separation
- Aggregate unread messages with other alerts into a single header badge
- Add border selector section to theme modal and persist user choice in local storage

## Testing
- `php -l includes/header.php`
- `node --check assets/theme-toggle.js`
- `npx -y stylelint assets/style.css --formatter=verbose`


------
https://chatgpt.com/codex/tasks/task_e_68b7d35c9fc4832b89feab38292ca40d