### PR TITLE
Improve cart interactions, request shipping updates, and expand trading system

### DIFF
--- a/assets/bell.svg
+++ b/assets/bell.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"/>
+  <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+</svg>

--- a/assets/buy.js
+++ b/assets/buy.js
@@ -3,6 +3,23 @@ document.addEventListener('DOMContentLoaded', () => {
   const listBtn = document.querySelector('.view-list');
   const container = document.getElementById('product-container');
 
+  const showToast = message => {
+    const toast = document.createElement('div');
+    toast.textContent = message;
+    Object.assign(toast.style, {
+      position: 'fixed',
+      bottom: '1rem',
+      right: '1rem',
+      background: '#333',
+      color: '#fff',
+      padding: '0.5rem 1rem',
+      borderRadius: '4px',
+      zIndex: 1000
+    });
+    document.body.appendChild(toast);
+    setTimeout(() => toast.remove(), 3000);
+  };
+
   if (gridBtn && listBtn && container) {
     gridBtn.addEventListener('click', () => {
       container.classList.remove('list-view');
@@ -29,8 +46,20 @@ document.addEventListener('DOMContentLoaded', () => {
         credentials: 'same-origin'
       })
         .then(res => res.json())
-        .then(() => {
-          window.location.href = 'cart.php';
+        .then(data => {
+          if (data.success) {
+            showToast('Added to cart');
+            const cartLink = document.querySelector('.cart-link a');
+            if (cartLink) {
+              let badge = cartLink.querySelector('.badge');
+              if (!badge) {
+                badge = document.createElement('span');
+                badge.className = 'badge';
+                cartLink.appendChild(badge);
+              }
+              badge.textContent = data.count;
+            }
+          }
         });
     });
   });

--- a/assets/style.css
+++ b/assets/style.css
@@ -16,6 +16,7 @@
   --pattern-sat: 100%;
   --btn-depth: 6px;
   --cta-depth: 20px;
+  --border-style: none;
 }
 
 [data-theme='dark'] {
@@ -154,6 +155,21 @@ body {
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
+.cta-buttons > a {
+  width: 100%;
+}
+
+.cta-primary {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+}
+
+.cta-primary a {
+  width: 100%;
+}
+
 .btn-cta {
   background: linear-gradient(45deg, var(--accent), var(--vap2), var(--vap3));
   background-size: 300% 300%;
@@ -190,12 +206,11 @@ body {
     padding: 3rem 2rem;
   }
 
-  .cta-buttons {
+  .cta-primary {
     flex-direction: row;
-    justify-content: center;
   }
 
-  .cta-buttons a {
+  .cta-primary a {
     flex: 1;
   }
 }
@@ -212,9 +227,6 @@ body {
 }
 
 #theme-toggle {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--fg);
@@ -235,6 +247,13 @@ body {
   width: 1.5rem;
   height: auto;
   display: block;
+}
+
+.lang-theme-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
 }
 
 footer {
@@ -628,6 +647,24 @@ form button:active {
     inset 0 calc(var(--btn-depth) / 3) 0 rgba(0, 0, 0, 0.4);
 }
 
+#theme-modal .border-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+#theme-modal .border-options .btn {
+  font-family: monospace;
+}
+
+#theme-modal .border-options .btn.active {
+  transform: perspective(400px) translateZ(calc(var(--btn-depth) / 3));
+  box-shadow: inset 0 -2px 0 rgba(255, 255, 255, 0.2),
+    inset 0 2px 0 rgba(0, 0, 0, 0.4),
+    inset 0 calc(var(--btn-depth) / 3) 0 rgba(0, 0, 0, 0.4);
+}
+
 #theme-modal .theme-error {
   color: #c00;
   margin-bottom: 1rem;
@@ -636,8 +673,14 @@ form button:active {
 #theme-preview {
   margin: 1rem 0;
   padding: 1rem;
-  border: 1px solid var(--fg);
+  border: 8px solid transparent;
+  border-image: var(--border-style);
   text-align: center;
+}
+
+body {
+  border: 12px solid transparent;
+  border-image: var(--border-style);
 }
 
 /* Tables */

--- a/assets/themes.json
+++ b/assets/themes.json
@@ -1,4 +1,9 @@
 {
+  "borders": {
+    "star": { "label": "Stars", "char": "*" },
+    "pipe": { "label": "Pipes", "char": "|" },
+    "hash": { "label": "Hashes", "char": "#" }
+  },
   "light": {
     "label": "Light",
     "vars": {

--- a/cart.php
+++ b/cart.php
@@ -17,7 +17,10 @@ if (isset($_GET['action']) && $_GET['action'] === 'add' && $_SERVER['REQUEST_MET
         }
     }
     header('Content-Type: application/json');
-    echo json_encode(['success' => true]);
+    echo json_encode([
+        'success' => true,
+        'count' => count($_SESSION['cart'])
+    ]);
     exit;
 }
 

--- a/includes/header.php
+++ b/includes/header.php
@@ -32,7 +32,8 @@ if (!empty($_SESSION['user_id'])) {
       $stmt->close();
     }
 
-    $unread_notifications = count_unread_notifications($conn, $_SESSION['user_id']);
+    $notif_types = ['service_request', 'shipping_update', 'request_message', 'admin_message'];
+    $unread_notifications = count_unread_notifications($conn, $_SESSION['user_id'], $notif_types);
   }
   $cart_count = isset($_SESSION['cart']) ? count($_SESSION['cart']) : 0;
 ?>
@@ -57,23 +58,29 @@ if (!empty($_SESSION['user_id'])) {
       <li><a href="/register.php" data-i18n="register">Register</a></li>
 <?php else: ?>
       <li><a href="/dashboard.php" data-i18n="dashboard">Dashboard</a></li>
-      <li><a href="/notifications.php" data-i18n="notifications">Notifications<?php if (!empty($unread_notifications)): ?><span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a></li>
+      <li><a href="/inventory.php">Inventory</a></li>
+      <li class="notifications-link">
+        <a href="/notifications.php" aria-label="Notifications">
+          <img src="/assets/bell.svg" alt="">
+          <?php if (!empty($unread_notifications)): ?><span class="badge"><?= $unread_notifications ?></span><?php endif; ?>
+        </a>
+      </li>
       <li><a href="/messages.php" data-i18n="messages">Messages<?php if (!empty($unread_messages)): ?><span class="badge"><?= $unread_messages ?></span><?php endif; ?></a></li>
       <li><a href="/logout.php" data-i18n="logout">Logout</a></li>
       <li class="user-info"><?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?></li>
 <?php endif; ?>
       <li class="cart-link">
-        <a href="/checkout.php">
+        <a href="/cart.php">
           <img src="/assets/cart.svg" alt="Cart">
           <?php if (!empty($cart_count)): ?><span class="badge"><?= $cart_count ?></span><?php endif; ?>
         </a>
       </li>
-      <li>
+      <li class="lang-theme-buttons">
         <button id="language-toggle" type="button" aria-haspopup="menu" aria-controls="language-menu">
           <img src="/assets/flags/en.svg" alt="English">
         </button>
+        <button id="theme-toggle" type="button" aria-haspopup="dialog" aria-controls="theme-modal">Themes</button>
       </li>
-      <li><button id="theme-toggle" type="button" aria-haspopup="dialog" aria-controls="theme-modal">Themes</button></li>
     </ul>
   </nav>
 </header>

--- a/index.php
+++ b/index.php
@@ -16,20 +16,22 @@ session_start();
       <div class="hero-ascii">
         <pre>
  ____  _              _____
-/ ___|| | ___   _ ___| ____|
-\___ \| |/ / | | |_  /  _|
+ / ___|| | ___   _ ___| ____|
+ \___ \| |/ / | | |_  /  _|
  ___) |   <| |_| |/ /| |___
-|____/|_|\\__,_/___|_____|
+ |____/|_|\\__,_/___|_____|
         </pre>
       </div>
       <div class="hero-content">
         <h2>Repair. Modding. Modern Support.</h2>
         <p>Whether you're fixing, upgrading, or building — SkuzE has you covered.</p>
         <div class="cta-buttons">
-          <a href="buy.php" class="btn-cta">Buy</a>
-          <a href="sell.php" class="btn-cta">Sell</a>
-          <a href="trade.php" class="btn-cta">Trade</a>
           <a href="services.php" class="btn-cta">Services</a>
+          <div class="cta-primary">
+            <a href="buy.php" class="btn-cta">Buy</a>
+            <a href="sell.php" class="btn-cta">Sell</a>
+            <a href="trade.php" class="btn-cta">Trade</a>
+          </div>
         </div>
       </div>
     </div>

--- a/inventory.php
+++ b/inventory.php
@@ -1,0 +1,75 @@
+<?php
+require 'includes/auth.php';
+require 'includes/db.php';
+require 'includes/csrf.php';
+
+$user_id = $_SESSION['user_id'];
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_token($_POST['csrf_token'] ?? '')) {
+        $error = 'Invalid CSRF token.';
+    } else {
+        $action = $_POST['action'] ?? '';
+        if ($action === 'add') {
+            $item = trim($_POST['item'] ?? '');
+            if ($item === '') {
+                $error = 'Item name required.';
+            } else {
+                if ($stmt = $conn->prepare('INSERT INTO user_inventory (user_id, item_name) VALUES (?, ?)')) {
+                    $stmt->bind_param('is', $user_id, $item);
+                    $stmt->execute();
+                    $stmt->close();
+                }
+            }
+        } elseif ($action === 'delete') {
+            $item_id = intval($_POST['item_id'] ?? 0);
+            if ($stmt = $conn->prepare('DELETE FROM user_inventory WHERE id = ? AND user_id = ?')) {
+                $stmt->bind_param('ii', $item_id, $user_id);
+                $stmt->execute();
+                $stmt->close();
+            }
+        }
+    }
+}
+
+$items = [];
+if ($stmt = $conn->prepare('SELECT id, item_name FROM user_inventory WHERE user_id = ? ORDER BY item_name')) {
+    $stmt->bind_param('i', $user_id);
+    $stmt->execute();
+    $items = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <meta charset="UTF-8">
+  <title>Your Inventory</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <h2>Your Inventory</h2>
+  <?php if ($error): ?><p class="error"><?= htmlspecialchars($error) ?></p><?php endif; ?>
+  <ul>
+    <?php foreach ($items as $i): ?>
+      <li>
+        <?= htmlspecialchars($i['item_name']) ?>
+        <form method="post" style="display:inline">
+          <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+          <input type="hidden" name="action" value="delete">
+          <input type="hidden" name="item_id" value="<?= $i['id'] ?>">
+          <button type="submit">Delete</button>
+        </form>
+      </li>
+    <?php endforeach; ?>
+  </ul>
+  <form method="post">
+    <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+    <input type="hidden" name="action" value="add">
+    <label>New Item:<br><input type="text" name="item"></label>
+    <button type="submit">Add</button>
+  </form>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>

--- a/migrations/014_add_shipping_fields_to_service_requests.sql
+++ b/migrations/014_add_shipping_fields_to_service_requests.sql
@@ -1,0 +1,4 @@
+ALTER TABLE service_requests
+  ADD COLUMN shipping_status VARCHAR(50) DEFAULT NULL,
+  ADD COLUMN tracking_number VARCHAR(100) DEFAULT NULL,
+  ADD COLUMN user_message TEXT DEFAULT NULL;

--- a/migrations/015_create_user_inventory.sql
+++ b/migrations/015_create_user_inventory.sql
@@ -1,0 +1,11 @@
+ALTER TABLE trade_offers
+  MODIFY offer_item TEXT NULL,
+  ADD COLUMN offer_items TEXT NULL,
+  ADD COLUMN request_items TEXT NULL;
+
+CREATE TABLE user_inventory (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  item_name VARCHAR(255) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);

--- a/schema/trade_tables.sql
+++ b/schema/trade_tables.sql
@@ -15,7 +15,9 @@ CREATE TABLE trade_offers (
     listing_id INT NOT NULL,
     offerer_id INT NOT NULL,
     message TEXT,
-    offer_item VARCHAR(255) NOT NULL,
+    offer_item TEXT,
+    offer_items TEXT,
+    request_items TEXT,
     status ENUM('pending','accepted','declined') DEFAULT 'pending',
     fulfillment_type ENUM('meetup','ship_to_skuzE'),
     shipping_address TEXT,
@@ -24,4 +26,11 @@ CREATE TABLE trade_offers (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (listing_id) REFERENCES trade_listings(id),
     FOREIGN KEY (offerer_id) REFERENCES users(id)
+);
+
+CREATE TABLE user_inventory (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    item_name VARCHAR(255) NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
 );

--- a/trade-offer.php
+++ b/trade-offer.php
@@ -7,6 +7,7 @@ $user_id = $_SESSION['user_id'];
 $listing_id = isset($_GET['id']) ? intval($_GET['id']) : 0;
 $error = '';
 $listing = null;
+$step = 'select';
 
 if ($listing_id) {
     if ($stmt = $conn->prepare('SELECT tl.id, tl.have_item, tl.want_item, tl.status, tl.owner_id, u.username FROM trade_listings tl JOIN users u ON tl.owner_id = u.id WHERE tl.id = ?')) {
@@ -21,24 +22,61 @@ if (!$listing || $listing['status'] !== 'open' || $listing['owner_id'] == $user_
     die('Listing not available for offers.');
 }
 
+function fetch_inventory($conn, $uid) {
+    $items = [];
+    if ($stmt = $conn->prepare('SELECT id, item_name FROM user_inventory WHERE user_id = ? ORDER BY item_name')) {
+        $stmt->bind_param('i', $uid);
+        $stmt->execute();
+        $items = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+    }
+    return $items;
+}
+
+$your_items = fetch_inventory($conn, $user_id);
+$their_items = fetch_inventory($conn, $listing['owner_id']);
+$your_map = array_column($your_items, 'item_name', 'id');
+$their_map = array_column($their_items, 'item_name', 'id');
+
+$selected_offer = [];
+$selected_request = [];
+$message = '';
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $step = $_POST['step'] ?? 'select';
     if (!validate_token($_POST['csrf_token'] ?? '')) {
         $error = 'Invalid CSRF token.';
+        $step = 'select';
     } else {
-        $offer_item = trim($_POST['offer_item'] ?? '');
         $message = trim($_POST['message'] ?? '');
-        if ($offer_item === '') {
-            $error = 'Offer item is required.';
-        }
-        if (!$error) {
-            if ($stmt = $conn->prepare('INSERT INTO trade_offers (listing_id, offerer_id, message, offer_item) VALUES (?,?,?,?)')) {
-                $stmt->bind_param('iiss', $listing_id, $user_id, $message, $offer_item);
-                $stmt->execute();
-                $stmt->close();
-                header('Location: trade-listings.php');
-                exit;
-            } else {
-                $error = 'Database error.';
+        if ($step === 'review') {
+            $selected_offer = array_map('intval', $_POST['offer_items'] ?? []);
+            $selected_request = array_map('intval', $_POST['request_items'] ?? []);
+            if (empty($selected_offer) && empty($selected_request)) {
+                $error = 'Select at least one item.';
+                $step = 'select';
+            }
+        } elseif ($step === 'confirm') {
+            $selected_offer = array_map('intval', $_POST['offer_items'] ?? []);
+            $selected_request = array_map('intval', $_POST['request_items'] ?? []);
+            if (empty($selected_offer) && empty($selected_request)) {
+                $error = 'Select at least one item.';
+                $step = 'select';
+            }
+            if (!$error) {
+                $offer_json = json_encode(array_values(array_intersect_key($your_map, array_flip($selected_offer))));
+                $request_json = json_encode(array_values(array_intersect_key($their_map, array_flip($selected_request))));
+                if ($stmt = $conn->prepare('INSERT INTO trade_offers (listing_id, offerer_id, message, offer_item, offer_items, request_items) VALUES (?,?,?,?,?,?)')) {
+                    $empty = '';
+                    $stmt->bind_param('iissss', $listing_id, $user_id, $message, $empty, $offer_json, $request_json);
+                    $stmt->execute();
+                    $stmt->close();
+                    header('Location: trade-listings.php');
+                    exit;
+                } else {
+                    $error = 'Database error.';
+                    $step = 'select';
+                }
             }
         }
     }
@@ -53,15 +91,39 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Offer Trade to <?= htmlspecialchars($listing['username']) ?></h2>
-  <p>They have: <strong><?= htmlspecialchars($listing['have_item']) ?></strong></p>
-  <p>They want: <strong><?= htmlspecialchars($listing['want_item']) ?></strong></p>
   <?php if ($error): ?><p class="error"><?= htmlspecialchars($error) ?></p><?php endif; ?>
-  <form method="post">
-    <label>Your Item Offer:<br><input type="text" name="offer_item" required></label><br>
-    <label>Message:<br><textarea name="message"></textarea></label><br>
-    <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
-    <button type="submit">Submit Offer</button>
-  </form>
+  <?php if ($step === 'select'): ?>
+    <form method="post">
+      <p>Select items you will give:</p>
+      <?php foreach ($your_items as $item): ?>
+        <label><input type="checkbox" name="offer_items[]" value="<?= $item['id'] ?>"> <?= htmlspecialchars($item['item_name']) ?></label><br>
+      <?php endforeach; ?>
+      <p>Select items you want from <?= htmlspecialchars($listing['username']) ?>:</p>
+      <?php foreach ($their_items as $item): ?>
+        <label><input type="checkbox" name="request_items[]" value="<?= $item['id'] ?>"> <?= htmlspecialchars($item['item_name']) ?></label><br>
+      <?php endforeach; ?>
+      <label>Message:<br><textarea name="message"></textarea></label><br>
+      <input type="hidden" name="step" value="review">
+      <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+      <button type="submit">Review Offer</button>
+    </form>
+  <?php elseif ($step === 'review'): ?>
+    <h3>Review Your Offer</h3>
+    <p>You will give: <?= htmlspecialchars(implode(', ', array_values(array_intersect_key($your_map, array_flip($selected_offer))))) ?: 'Nothing' ?></p>
+    <p>You will receive: <?= htmlspecialchars(implode(', ', array_values(array_intersect_key($their_map, array_flip($selected_request))))) ?: 'Nothing' ?></p>
+    <form method="post" style="display:inline">
+      <?php foreach ($selected_offer as $id): ?><input type="hidden" name="offer_items[]" value="<?= $id ?>"><?php endforeach; ?>
+      <?php foreach ($selected_request as $id): ?><input type="hidden" name="request_items[]" value="<?= $id ?>"><?php endforeach; ?>
+      <input type="hidden" name="message" value="<?= htmlspecialchars($message, ENT_QUOTES) ?>">
+      <input type="hidden" name="step" value="confirm">
+      <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+      <button type="submit">Confirm Offer</button>
+    </form>
+    <form method="get" style="display:inline">
+      <input type="hidden" name="id" value="<?= $listing_id ?>">
+      <button type="submit">Back</button>
+    </form>
+  <?php endif; ?>
   <?php include 'includes/footer.php'; ?>
 </body>
 </html>

--- a/trade-offers.php
+++ b/trade-offers.php
@@ -59,7 +59,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $offers = [];
-if ($stmt = $conn->prepare('SELECT o.id, o.offer_item, o.message, o.status, u.username FROM trade_offers o JOIN users u ON o.offerer_id = u.id WHERE o.listing_id = ? ORDER BY o.created_at DESC')) {
+if ($stmt = $conn->prepare('SELECT o.id, o.offer_item, o.offer_items, o.request_items, o.message, o.status, u.username FROM trade_offers o JOIN users u ON o.offerer_id = u.id WHERE o.listing_id = ? ORDER BY o.created_at DESC')) {
     $stmt->bind_param('i', $listing_id);
     $stmt->execute();
     $offers = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
@@ -79,11 +79,16 @@ if ($stmt = $conn->prepare('SELECT o.id, o.offer_item, o.message, o.status, u.us
   <p>You want: <strong><?= htmlspecialchars($listing['want_item']) ?></strong></p>
   <?php if ($error): ?><p class="error"><?= htmlspecialchars($error) ?></p><?php endif; ?>
   <table>
-    <tr><th>Offerer</th><th>Offer Item</th><th>Message</th><th>Status</th><th>Actions</th></tr>
+    <tr><th>Offerer</th><th>Offers</th><th>Requests</th><th>Message</th><th>Status</th><th>Actions</th></tr>
     <?php foreach ($offers as $o): ?>
+      <?php
+        $give = $o['offer_items'] ? json_decode($o['offer_items'], true) : ($o['offer_item'] ? [$o['offer_item']] : []);
+        $take = $o['request_items'] ? json_decode($o['request_items'], true) : [];
+      ?>
       <tr>
         <td><?= htmlspecialchars($o['username']) ?></td>
-        <td><?= htmlspecialchars($o['offer_item']) ?></td>
+        <td><?= htmlspecialchars(implode(', ', $give)) ?></td>
+        <td><?= htmlspecialchars(implode(', ', $take)) ?></td>
         <td><?= htmlspecialchars($o['message']) ?></td>
         <td><?= htmlspecialchars($o['status']) ?></td>
         <td>


### PR DESCRIPTION
## Summary
- Link header cart icon to dedicated cart page
- Show toast and update cart count when adding items
- Return cart count from cart endpoint
- Stack language and theme controls vertically in header
- Allow admins to track shipping status, store tracking numbers, and send user messages with notifications
- Add migration to persist shipping info on service requests
- Align hero ASCII logo spacing on the homepage for consistent rendering
- Aggregate notification badge across service requests, shipping updates, and admin messages
- Replace notification text link with bell SVG and aria-label
- Place Services link on its own row above the Buy/Sell/Trade buttons and center layout
- Add selectable ASCII border styles with theme toggle
- Introduce user inventory management and multi-item trade offers with review/confirmation

## Testing
- `php -l includes/header.php`
- `php -l cart.php`
- `php -l admin/view.php`
- `php -l trade-offer.php`
- `php -l trade-offers.php`
- `php -l inventory.php`
- `node --check assets/buy.js && echo "JS OK"`
- `npm test` *(fails: Could not read package.json)*
- `php cart.php` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d455309c832ba14b4178d0f8cf62