### PR TITLE
Improve trade navigation and add service request wizard

### DIFF
--- a/api/models.php
+++ b/api/models.php
@@ -1,0 +1,16 @@
+<?php
+require '../includes/db.php';
+header('Content-Type: application/json');
+
+$brand_id = isset($_GET['brand_id']) ? (int)$_GET['brand_id'] : 0;
+$models = [];
+if ($brand_id > 0 && $stmt = $conn->prepare('SELECT id, name FROM service_models WHERE brand_id=? ORDER BY name')) {
+    $stmt->bind_param('i', $brand_id);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    while ($row = $res->fetch_assoc()) {
+        $models[] = ['id' => (int)$row['id'], 'name' => $row['name']];
+    }
+    $stmt->close();
+}
+echo json_encode($models);

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -6,8 +6,9 @@
       <li><a href="services.php">Services</a></li>
       <li><a href="buy.php">Buy</a></li>
       <li><a href="sell.php">Sell</a></li>
-      <li><a href="trade.php">Trade</a></li>
+      <li><a href="trade.php">Trade Offers</a></li>
       <li><a href="trade-listings.php">Trade Listings</a></li>
+      <li><a href="trade-listing.php">Create Listing</a></li>
       <li><a href="promoted.php">Promoted Shops</a></li>
       <li><a href="vip.php">VIP Membership</a></li>
     </ul>

--- a/migrations/012_create_service_brands.sql
+++ b/migrations/012_create_service_brands.sql
@@ -1,0 +1,4 @@
+CREATE TABLE service_brands (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);

--- a/migrations/013_create_service_models.sql
+++ b/migrations/013_create_service_models.sql
@@ -1,0 +1,6 @@
+CREATE TABLE service_models (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    brand_id INT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    FOREIGN KEY (brand_id) REFERENCES service_brands(id)
+);

--- a/migrations/014_add_brand_model_to_service_requests.sql
+++ b/migrations/014_add_brand_model_to_service_requests.sql
@@ -1,0 +1,3 @@
+ALTER TABLE service_requests
+    ADD COLUMN brand_id INT NULL,
+    ADD COLUMN model_id INT NULL;

--- a/service-step.php
+++ b/service-step.php
@@ -8,7 +8,8 @@ require 'includes/csrf.php';
 // Only a category is expected – if it is missing send the user back to
 // the service selection page.
 $category = $_GET['category'] ?? '';
-if (!$category) {
+$allowed = ['repair', 'clean', 'build', 'other'];
+if (!in_array($category, $allowed)) {
   header('Location: services.php');
   exit;
 }
@@ -32,14 +33,14 @@ function label($text, $name, $type = 'text', $required = true) {
       <input type="hidden" name="type" value="service">
       <input type="hidden" name="category" value="<?= htmlspecialchars($category) ?>">
 
-    <?php if ($category === 'phone' || $category === 'console' || $category === 'pc'): ?>
+    <?php if (in_array($category, ['repair', 'clean', 'build'])): ?>
       <?php label("Make", "make"); ?>
       <?php label("Model", "model"); ?>
       <?php label("IMEI / Serial Number", "serial", 'text', false); ?>
       <?php label("Describe the problem", "issue"); ?>
     <?php endif; ?>
 
-    <?php if ($category === 'pc'): ?>
+    <?php if ($category === 'build'): ?>
       <label>Is this a custom build request?</label>
       <select name="build">
         <option value="no">No</option>

--- a/tests/service_category_flow_test.php
+++ b/tests/service_category_flow_test.php
@@ -1,0 +1,20 @@
+<?php
+function assert_contains(string $needle, string $haystack, string $message): void {
+    if (strpos($haystack, $needle) === false) {
+        throw new Exception($message);
+    }
+}
+
+$base = __DIR__ . '/..';
+$services = file_get_contents($base . '/services.php');
+$step = file_get_contents($base . '/service-step.php');
+
+$categories = ['repair', 'clean', 'build', 'other'];
+foreach ($categories as $cat) {
+    assert_contains('data-category="' . $cat . '"', $services, "Missing $cat button");
+    assert_contains("'$cat'", $step, "Service step missing $cat handling");
+}
+assert_contains('Device Type', $step, 'Device type field missing');
+assert_contains('Make', $step, 'Make field missing');
+
+echo "All service category flow tests passed\n";

--- a/tests/service_wizard_test.php
+++ b/tests/service_wizard_test.php
@@ -1,0 +1,19 @@
+<?php
+function assert_contains(string $needle, string $haystack, string $message): void {
+    if (strpos($haystack, $needle) === false) {
+        throw new Exception($message);
+    }
+}
+
+$base = __DIR__ . '/..';
+$services = file_get_contents($base . '/services.php');
+assert_contains('data-step="1"', $services, 'Wizard missing step 1');
+assert_contains('data-category="repair"', $services, 'Repair option missing');
+assert_contains('name="brand_id"', $services, 'Brand select missing');
+assert_contains('api/models.php', $services, 'Model API endpoint missing');
+assert_contains('name="model_id"', $services, 'Model select missing');
+assert_contains('name="issue"', $services, 'Issue field missing');
+assert_contains('Please select a brand', $services, 'Client validation for brand missing');
+assert_contains('Please select a model', $services, 'Client validation for model missing');
+
+echo "All service wizard tests passed\n";

--- a/tests/trade_navigation_test.php
+++ b/tests/trade_navigation_test.php
@@ -1,0 +1,22 @@
+<?php
+function assert_contains(string $needle, string $haystack, string $message): void {
+    if (strpos($haystack, $needle) === false) {
+        throw new Exception($message);
+    }
+}
+
+$base = __DIR__ . '/..';
+$sidebar = file_get_contents($base . '/includes/sidebar.php');
+assert_contains('href="trade.php"', $sidebar, 'Sidebar missing Trade Offers link');
+assert_contains('Trade Offers', $sidebar, 'Sidebar should label Trade Offers');
+assert_contains('href="trade-listing.php"', $sidebar, 'Sidebar missing Create Listing link');
+
+$trade = file_get_contents($base . '/trade.php');
+assert_contains('href="trade-listing.php"', $trade, 'Trade page missing link to create listing');
+
+$listings = file_get_contents($base . '/trade-listings.php');
+assert_contains('href="trade.php"', $listings, 'Listings page missing link back to trade offers');
+assert_contains('href="trade-listing.php"', $listings, 'Listings page missing link to create listing');
+
+echo "All trade navigation tests passed\n";
+

--- a/trade-listings.php
+++ b/trade-listings.php
@@ -34,7 +34,10 @@ if ($result = $conn->query($sql)) {
   <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Trade Listings</h2>
-  <p><a href="trade-listing.php">Create new trade listing</a></p>
+  <p>
+    <a href="trade.php">Trade Offers</a> |
+    <a href="trade-listing.php">Create Listing</a>
+  </p>
   <table>
     <tr><th>Have</th><th>Want</th><th>Status</th><th>Owner</th><th>Actions</th></tr>
     <?php foreach ($listings as $l): ?>

--- a/trade.php
+++ b/trade.php
@@ -61,6 +61,9 @@ if ($listing_filter) {
   <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>Trade Offers</h2>
+  <?php if ($user_id): ?>
+    <p><a class="button" href="trade-listing.php">Create Trade Listing</a></p>
+  <?php endif; ?>
   <?php if ($error): ?><p class="error"><?= htmlspecialchars($error) ?></p><?php endif; ?>
   <?php if ($offers): ?>
     <table>


### PR DESCRIPTION
## Summary
- Add "Trade Offers", "Trade Listings", and "Create Listing" entries to the sidebar
- Provide "Create Trade Listing" button on trade offers page
- Link trade listings page back to trade offers and include quick create listing link
- Replace one-step service modal with a four-step wizard for type, brand, model, and issue details
- Validate brand and model IDs, store them on submission, and expose an API for model lookup
- Standardize service categories and dynamically adjust wizard steps for the "Other" type
- Add regression tests ensuring each service category presents the correct form

## Testing
- `php -l includes/sidebar.php trade.php trade-listings.php tests/trade_navigation_test.php services.php service-step.php submit-request.php api/models.php tests/service_wizard_test.php tests/service_category_flow_test.php`
- `php tests/trade_navigation_test.php`
- `php tests/service_wizard_test.php`
- `php tests/service_category_flow_test.php`

------
https://chatgpt.com/codex/tasks/task_e_68b7ece8c7f4832b8981044baa5f5068