### PR TITLE
Refactor header icons and navigation layouts

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -22,15 +22,30 @@ $requests = $stmt->fetch_all(MYSQLI_ASSOC);
 <body>
   <?php include '../includes/header.php'; ?>
   <h2>Admin Panel</h2>
-  <div class="nav-links">
-    <a class="btn" href="listings.php">Review Listings</a>
-    <a class="btn" href="trade-requests.php">Review Trade Requests</a>
-    <a class="btn" href="discount-codes.php">Manage Discount Codes</a>
-    <a class="btn" href="users.php">Manage Users</a>
-    <a class="btn" href="theme.php">Vaporwave Theme Settings</a>
-    <a class="btn" href="toolbox.php">Manage Toolbox</a>
-    <a class="btn" href="../dashboard.php">Back to Dashboard</a>
+  <div class="nav-sections">
+    <div class="nav-section">
+      <h3>Listings</h3>
+      <ul class="nav-links">
+        <li><a class="btn" href="listings.php">Review Listings</a></li>
+      </ul>
+    </div>
+    <div class="nav-section">
+      <h3>Trades</h3>
+      <ul class="nav-links">
+        <li><a class="btn" href="trade-requests.php">Review Trade Requests</a></li>
+      </ul>
+    </div>
+    <div class="nav-section">
+      <h3>System</h3>
+      <ul class="nav-links">
+        <li><a class="btn" href="discount-codes.php">Manage Discount Codes</a></li>
+        <li><a class="btn" href="users.php">Manage Users</a></li>
+        <li><a class="btn" href="theme.php">Vaporwave Theme Settings</a></li>
+        <li><a class="btn" href="toolbox.php">Manage Toolbox</a></li>
+      </ul>
+    </div>
   </div>
+  <p class="back-link"><a class="btn" href="../dashboard.php">Back to Dashboard</a></p>
 
   <table>
     <thead>

--- a/assets/buy.js
+++ b/assets/buy.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.addEventListener('click', e => {
       e.preventDefault();
       const id = btn.dataset.id;
-      fetch('cart.php?action=add', {
+      fetch('/cart.php?action=add', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded'

--- a/assets/style.css
+++ b/assets/style.css
@@ -120,6 +120,7 @@ body.site-frame {
 .hero-ascii {
   display: flex;
   justify-content: center;
+  width: 100%;
 }
 
 .hero-ascii pre {
@@ -147,8 +148,10 @@ body.site-frame {
   margin: 2rem auto 0;
 }
 
+
 .cta-row {
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   width: 100%;
   justify-content: center;
@@ -156,6 +159,19 @@ body.site-frame {
 
 .cta-row a {
   flex: 1;
+}
+
+.cta-row.full a {
+  flex: 1 0 100%;
+  max-width: 600px;
+  display: block;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .cta-row {
+    flex-direction: column;
+  }
 }
 
 
@@ -244,6 +260,7 @@ body.site-frame {
   flex-direction: column;
   gap: 0.25rem;
   align-items: center;
+  margin-left: auto;
 }
 
 @media (max-width: 600px) {
@@ -403,7 +420,7 @@ footer:hover {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: center;
+  align-items: stretch;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
   background: linear-gradient(135deg, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0)), var(--gradient);
@@ -444,28 +461,29 @@ footer:hover {
 .header-center,
 .header-right {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-
+  align-items: stretch;
+  flex: 1;
   background: var(--bg);
   color: var(--fg);
-  padding: 0.5rem;
-
   padding: 0.25rem 0.5rem;
   background: rgba(0, 0, 0, 0.3);
   background: color-mix(in srgb, var(--bg) 60%, transparent);
-
   border-radius: 4px;
 }
 
-.header-left,
-.header-right {
-  flex: 1;
+.header-left {
+  justify-content: space-between;
 }
 
 .header-center {
-  flex: 1;
   justify-content: center;
+}
+
+.header-right {
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-start;
+  gap: 0.5rem;
 }
 
 .site-search {
@@ -651,10 +669,18 @@ form button:active {
 }
 
 .nav-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   justify-content: center;
+}
+
+.back-link {
+  text-align: center;
+  margin-top: 1rem;
 }
 
 .btn {
@@ -908,25 +934,22 @@ tbody tr:nth-child(even) {
   flex-direction: row;
   text-align: left;
 }
-.product-card img {
-  width: 200px;
-  height: 200px;
+.thumb-square {
+  width: var(--thumb-size, 200px);
+  height: var(--thumb-size, 200px);
   object-fit: cover;
   border-radius: 4px;
 }
-.product-grid.list-view .product-card img {
-  width: 120px;
-  height: 120px;
+.product-grid.list-view .product-card .thumb-square {
+  --thumb-size: 120px;
   margin-right: 1rem;
 }
 @media (max-width: 600px) {
-  .product-card img {
-    width: 150px;
-    height: 150px;
+  .thumb-square {
+    --thumb-size: 150px;
   }
-  .product-grid.list-view .product-card img {
-    width: 100px;
-    height: 100px;
+  .product-grid.list-view .product-card .thumb-square {
+    --thumb-size: 100px;
   }
 }
 .product-features {
@@ -959,11 +982,8 @@ tbody tr:nth-child(even) {
   gap: 2rem;
   align-items: flex-start;
 }
-.listing-image img {
-  width: 300px;
-  height: 300px;
-  object-fit: cover;
-  border-radius: 4px;
+.listing-image .thumb-square {
+  --thumb-size: 300px;
 }
 .listing-info {
   flex: 1;
@@ -989,9 +1009,8 @@ tbody tr:nth-child(even) {
     flex-direction: column;
     align-items: center;
   }
-  .listing-image img {
-    width: 200px;
-    height: 200px;
+  .listing-image .thumb-square {
+    --thumb-size: 200px;
   }
   .listing-cta {
     align-items: center;

--- a/buy.php
+++ b/buy.php
@@ -116,7 +116,7 @@ $stmt->close();
             <?php $link = "listing.php?listing_id={$l['id']}"; ?>
             <a href="<?= $link ?>" class="listing-link">
               <?php if ($l['image']): ?>
-                <img src="uploads/<?= htmlspecialchars($l['image']) ?>" alt="">
+                <img class="thumb-square" src="uploads/<?= htmlspecialchars($l['image']) ?>" alt="">
               <?php endif; ?>
               <h3><?= htmlspecialchars($l['title']) ?></h3>
             </a>

--- a/dashboard.php
+++ b/dashboard.php
@@ -44,28 +44,28 @@ $unread_notifications = count_unread_notifications($conn, $id);
   <div class="nav-sections">
     <div class="nav-section">
       <h3>Service Requests</h3>
-      <div class="nav-links">
-        <a class="btn" role="button" href="services.php">Start a Service Request</a>
-        <a class="btn" role="button" href="my-requests.php">View My Service Requests</a>
-        <a class="btn" role="button" href="my-listings.php">Manage My Listings</a>
-      </div>
+      <ul class="nav-links">
+        <li><a class="btn" role="button" href="services.php">Start a Service Request</a></li>
+        <li><a class="btn" role="button" href="my-requests.php">View My Service Requests</a></li>
+        <li><a class="btn" role="button" href="my-listings.php">Manage My Listings</a></li>
+      </ul>
     </div>
     <div class="nav-section">
       <h3>Communications</h3>
-      <div class="nav-links">
-        <a class="btn" role="button" href="notifications.php">Notifications<?php if (!empty($unread_notifications)): ?> <span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a>
-        <a class="btn" role="button" href="messages.php">Messages<?php if (!empty($unread_messages)): ?> <span class="badge"><?= $unread_messages ?></span><?php endif; ?></a>
-      </div>
+      <ul class="nav-links">
+        <li><a class="btn" role="button" href="notifications.php">Notifications<?php if (!empty($unread_notifications)): ?> <span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a></li>
+        <li><a class="btn" role="button" href="messages.php">Messages<?php if (!empty($unread_messages)): ?> <span class="badge"><?= $unread_messages ?></span><?php endif; ?></a></li>
+      </ul>
     </div>
     <div class="nav-section">
       <h3>Account</h3>
-      <div class="nav-links">
+      <ul class="nav-links">
         <?php if (!empty($_SESSION['is_admin'])): ?>
-          <a class="btn" role="button" href="/admin/index.php">Admin Panel</a>
+          <li><a class="btn" role="button" href="/admin/index.php">Admin Panel</a></li>
         <?php endif; ?>
-        <a class="btn" role="button" href="profile.php">Edit Profile</a>
-        <a class="btn" role="button" href="logout.php">Logout</a>
-      </div>
+        <li><a class="btn" role="button" href="profile.php">Edit Profile</a></li>
+        <li><a class="btn" role="button" href="logout.php">Logout</a></li>
+      </ul>
     </div>
   </div>
   <?php include 'includes/footer.php'; ?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -32,7 +32,7 @@ if (!empty($_SESSION['user_id'])):
   $unread_messages = count_unread_messages($conn, $_SESSION['user_id']);
   $unread_notifications = count_unread_notifications($conn, $_SESSION['user_id']);
   $unread_total = $unread_messages + $unread_notifications;
-  $cart_count = isset($_SESSION['cart']) ? count($_SESSION['cart']) : 0;
+  $cart_count = isset($_SESSION['cart']) ? array_sum($_SESSION['cart']) : 0;
 endif;
 ?>
 
@@ -53,6 +53,9 @@ endif;
     </form>
   </div>
   <nav class="site-nav header-right">
+<?php if (!empty($_SESSION['user_id'])): ?>
+    <div class="user-info"><?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?></div>
+<?php endif; ?>
     <ul>
 <?php if (empty($_SESSION['user_id'])): ?>
       <li><a href="/login.php" data-i18n="login">Login</a></li>
@@ -60,24 +63,20 @@ endif;
 <?php else: ?>
       <li><a href="/dashboard.php" data-i18n="dashboard">Dashboard</a></li>
 
-      <li><a href="/notifications.php" data-i18n="notifications">Notifications<?php if (!empty($unread_notifications)): ?><span class="badge"><?= $unread_notifications ?></span><?php endif; ?></a></li>
-      <li><a href="/messages.php" aria-label="Messages"><img src="/assets/message.svg" alt="" aria-hidden="true"><?php if (!empty($unread_messages)): ?><span class="badge"><?= $unread_messages ?></span><?php endif; ?></a></li>
-
       <li>
         <a href="/notifications.php" aria-label="Notifications<?= $unread_total ? ' (' . $unread_total . ' unread)' : '' ?>">
-          <img src="/assets/bell.svg" alt="">
+          <img src="/assets/bell.svg" alt="Notifications">
           <?php if (!empty($unread_total)): ?><span class="badge"><?= $unread_total ?></span><?php endif; ?>
         </a>
       </li>
       <li>
         <a href="/messages.php" aria-label="Messages<?= $unread_messages ? ' (' . $unread_messages . ' unread)' : '' ?>">
-          <img src="/assets/envelope.svg" alt="">
+          <img src="/assets/envelope.svg" alt="Messages">
           <?php if (!empty($unread_messages)): ?><span class="badge"><?= $unread_messages ?></span><?php endif; ?>
         </a>
       </li>
 
       <li><a href="/logout.php" data-i18n="logout">Logout</a></li>
-      <li class="user-info"><?= username_with_avatar($conn, $_SESSION['user_id'], $username) ?></li>
 <?php endif; ?>
       <li class="cart-link">
         <a href="/cart.php">

--- a/index.php
+++ b/index.php
@@ -15,18 +15,18 @@ session_start();
     <div class="hero">
       <div class="hero-ascii">
         <pre>
- ____  _              _____
+____  _              _____
 / ___|| | ___   _ ___| ____|
 \___ \| |/ / | | |_  /  _|
  ___) |   <| |_| |/ /| |___
 |____/|_|\\__,_/___|_____|
-        </pre>
+</pre>
       </div>
       <div class="hero-content">
         <h2>Repair. Modding. Modern Support.</h2>
         <p>Whether you're fixing, upgrading, or building — SkuzE has you covered.</p>
         <div class="cta-buttons">
-          <div class="cta-row">
+          <div class="cta-row full">
             <a href="services.php" class="btn-cta">Services</a>
           </div>
           <div class="cta-row">

--- a/listing.php
+++ b/listing.php
@@ -31,7 +31,7 @@ if (!$listing) {
   <div class="content listing-detail">
     <div class="listing-image">
       <?php if (!empty($listing['image'])): ?>
-        <img src="uploads/<?= htmlspecialchars($listing['image']); ?>" alt="<?= htmlspecialchars($listing['title']); ?>">
+        <img class="thumb-square" src="uploads/<?= htmlspecialchars($listing['image']); ?>" alt="<?= htmlspecialchars($listing['title']); ?>">
       <?php endif; ?>
     </div>
     <section class="listing-info">

--- a/my-listings.php
+++ b/my-listings.php
@@ -39,7 +39,7 @@ $stmt->close();
         <td><?= htmlspecialchars($l['title']) ?></td>
         <td><?= htmlspecialchars($l['price']) ?></td>
         <td><?= htmlspecialchars($l['category']) ?></td>
-        <td><?php if ($l['image']): ?><img src="uploads/<?= htmlspecialchars($l['image']) ?>" alt="" width="60"><?php endif; ?></td>
+        <td><?php if ($l['image']): ?><img class="thumb-square" style="--thumb-size:60px;" src="uploads/<?= htmlspecialchars($l['image']) ?>" alt=""><?php endif; ?></td>
         <td><?= htmlspecialchars($l['status']) ?></td>
         <td><a href="?delete=<?= $l['id'] ?>" onclick="return confirm('Delete listing?');">Delete</a></td>
       </tr>


### PR DESCRIPTION
## Summary
- Expand Services call-to-action into a full-width row and stack CTA buttons vertically on mobile
- Simplify notification and message navigation items to single icon links
- Add descriptive alt text for notification and message icons
- Align header sections with stretch-based flex layout and position user info above button list
- Use root-relative cart add path and show total item quantities in cart badge
- Extract reusable `.thumb-square` thumbnail class and apply to listing previews
- Organize dashboard and admin navigation links into grouped lists with shared styling
- Center landing page hero ASCII art and remove stray leading spaces for consistent alignment

## Testing
- `php -l buy.php`
- `php -l listing.php`
- `php -l my-listings.php`
- `php -l includes/header.php`
- `php -l cart.php`
- `node --check assets/buy.js`
- `php -l dashboard.php`
- `php -l admin/index.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7e8543968832bb8ddecb43998e061