### PR TITLE
Enhance theme settings with font and CTA customization and add user status flair

### DIFF
--- a/admin/theme.php
+++ b/admin/theme.php
@@ -34,6 +34,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         '--vap1' => $_POST['vap1'] ?? null,
         '--vap2' => $_POST['vap2'] ?? null,
         '--vap3' => $_POST['vap3'] ?? null,
+        '--font-header' => $_POST['font_header'] ?? "'Share Tech Mono', monospace",
+        '--font-body' => $_POST['font_body'] ?? "'Share Tech Mono', monospace",
+        '--font-paragraph' => $_POST['font_paragraph'] ?? "'Share Tech Mono', monospace",
+        '--cta-gradient' => $_POST['cta_gradient'] ?? 'linear-gradient(45deg, var(--accent), var(--vap2), var(--vap3))',
+        '--cta-depth' => isset($_POST['cta_depth']) && $_POST['cta_depth'] !== '' ? $_POST['cta_depth'] . 'px' : '20px',
       ],
     ];
     if (!empty($_POST['pattern_enabled'])) {
@@ -89,6 +94,15 @@ $current = $themes[$edit] ?? null;
     <label>Accent Color
       <input type="color" name="accent" value="<?= htmlspecialchars($current['vars']['--accent'] ?? '#ff71ce', ENT_QUOTES, 'UTF-8'); ?>">
     </label>
+    <label>Header Font
+      <input type="text" name="font_header" value="<?= htmlspecialchars($current['vars']['--font-header'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+    </label>
+    <label>Body Font
+      <input type="text" name="font_body" value="<?= htmlspecialchars($current['vars']['--font-body'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+    </label>
+    <label>Paragraph Font
+      <input type="text" name="font_paragraph" value="<?= htmlspecialchars($current['vars']['--font-paragraph'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+    </label>
     <div>
       <span>Gradient</span>
       <div class="gradient-presets">
@@ -100,6 +114,12 @@ $current = $themes[$edit] ?? null;
         <input type="text" id="gradient" name="gradient" value="<?= htmlspecialchars($current['vars']['--gradient'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
       </label>
     </div>
+    <label>CTA Gradient
+      <input type="text" name="cta_gradient" value="<?= htmlspecialchars($current['vars']['--cta-gradient'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+    </label>
+    <label>CTA Depth (px)
+      <input type="number" name="cta_depth" value="<?= htmlspecialchars(preg_replace('/[^0-9.]/', '', $current['vars']['--cta-depth'] ?? '20'), ENT_QUOTES, 'UTF-8'); ?>">
+    </label>
     <label>Vap Color 1
       <input type="color" name="vap1" value="<?= htmlspecialchars($current['vars']['--vap1'] ?? '#ff71ce', ENT_QUOTES, 'UTF-8'); ?>">
     </label>
@@ -111,24 +131,31 @@ $current = $themes[$edit] ?? null;
     </label>
     <label><input type="checkbox" id="pattern_toggle" name="pattern_enabled" <?= isset($current['pattern']) ? 'checked' : ''; ?>> Enable Pattern</label>
     <div id="pattern_settings" style="display: <?= isset($current['pattern']) ? 'block' : 'none'; ?>;">
+      <p class="help-text">The generated pattern is applied to the header and footer backgrounds.</p>
+      <p class="help-text"><strong>How it works:</strong> frequency sets how often the wave repeats, amplitude adjusts the wave height, the polynomial coefficients warp the curve, hue rotates the color, and saturation tweaks the color intensity.</p>
       <label>Pattern Frequency
-        <input type="range" min="0" max="10" step="0.1" id="pattern_freq" name="pattern_freq" value="<?= htmlspecialchars($current['pattern']['frequency'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="range" min="0" max="10" step="0.1" id="pattern_freq" name="pattern_freq" value="<?= htmlspecialchars($current['pattern']['frequency'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>" title="Controls how often the pattern repeats">
         <span id="pattern_freq_val"></span>
+        <small>Controls how often the pattern repeats.</small>
       </label>
       <label>Pattern Amplitude
-        <input type="range" min="0" max="10" step="0.1" id="pattern_amp" name="pattern_amp" value="<?= htmlspecialchars($current['pattern']['amplitude'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="range" min="0" max="10" step="0.1" id="pattern_amp" name="pattern_amp" value="<?= htmlspecialchars($current['pattern']['amplitude'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>" title="Adjusts the height of the wave">
         <span id="pattern_amp_val"></span>
+        <small>Adjusts the height of the wave.</small>
       </label>
       <label>Pattern Polynomial (comma-separated)
-        <input type="text" id="pattern_poly" name="pattern_poly" value="<?= htmlspecialchars(isset($current['pattern']['poly']) ? implode(',', $current['pattern']['poly']) : '', ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="text" id="pattern_poly" name="pattern_poly" value="<?= htmlspecialchars(isset($current['pattern']['poly']) ? implode(',', $current['pattern']['poly']) : '', ENT_QUOTES, 'UTF-8'); ?>" title="Comma-separated coefficients that bend the wave shape">
+        <small>Comma-separated coefficients that bend the wave shape.</small>
       </label>
       <label>Pattern Hue
-        <input type="range" min="0" max="360" id="pattern_hue" name="pattern_hue" value="<?= htmlspecialchars($current['pattern']['hue'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="range" min="0" max="360" id="pattern_hue" name="pattern_hue" value="<?= htmlspecialchars($current['pattern']['hue'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>" title="Rotates the pattern's base color">
         <span id="pattern_hue_val"></span>
+        <small>Rotates the pattern's base color.</small>
       </label>
       <label>Pattern Saturation
-        <input type="range" min="0" max="100" id="pattern_sat" name="pattern_sat" value="<?= htmlspecialchars($current['pattern']['sat'] ?? '100', ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="range" min="0" max="100" id="pattern_sat" name="pattern_sat" value="<?= htmlspecialchars($current['pattern']['sat'] ?? '100', ENT_QUOTES, 'UTF-8'); ?>" title="Changes the intensity of the pattern's color">
         <span id="pattern_sat_val"></span>
+        <small>Changes the intensity of the pattern's color.</small>
       </label>
     </div>
     <button type="submit">Save Theme</button>
@@ -157,6 +184,15 @@ $current = $themes[$edit] ?? null;
     <label>Accent Color
       <input type="color" name="accent" value="#ff71ce">
     </label>
+    <label>Header Font
+      <input type="text" name="font_header" value="'Share Tech Mono', monospace">
+    </label>
+    <label>Body Font
+      <input type="text" name="font_body" value="'Share Tech Mono', monospace">
+    </label>
+    <label>Paragraph Font
+      <input type="text" name="font_paragraph" value="'Share Tech Mono', monospace">
+    </label>
     <div>
       <span>Gradient</span>
       <div class="gradient-presets">
@@ -168,6 +204,12 @@ $current = $themes[$edit] ?? null;
         <input type="text" id="gradient" name="gradient" value="linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)">
       </label>
     </div>
+    <label>CTA Gradient
+      <input type="text" name="cta_gradient" value="linear-gradient(45deg, var(--accent), var(--vap2), var(--vap3))">
+    </label>
+    <label>CTA Depth (px)
+      <input type="number" name="cta_depth" value="20">
+    </label>
     <button type="submit">Create Theme</button>
   </form>
 <?php endif; ?>

--- a/admin/user-edit.php
+++ b/admin/user-edit.php
@@ -9,7 +9,7 @@ if (!$_SESSION['is_admin']) {
   exit;
 }
 
-$statuses = ['online', 'offline', 'busy'];
+$statuses = ['online', 'offline', 'busy', 'away']; // flair presets
 $id = (int)($_GET['id'] ?? 0);
 if ($id <= 0) {
   header('Location: users.php');
@@ -85,6 +85,7 @@ if ($stmt) {
         <?php endforeach; ?>
       </select>
     </label><br>
+    <p class="notice">Status controls the animated border shown with the user's name.</p>
     <label>
       <input type="checkbox" name="is_admin" value="1" <?= $is_admin ? 'checked' : '' ?>> Admin
     </label><br>

--- a/assets/admin-theme.js
+++ b/assets/admin-theme.js
@@ -4,6 +4,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!form) return;
 
   const gradientInput = document.getElementById('gradient');
+  const ctaGradientInput = form.querySelector('[name="cta_gradient"]');
+  const ctaDepthInput = form.querySelector('[name="cta_depth"]');
   document.querySelectorAll('.gradient-preset').forEach(btn => {
     btn.addEventListener('click', () => {
       gradientInput.value = btn.dataset.gradient;
@@ -40,9 +42,15 @@ document.addEventListener('DOMContentLoaded', () => {
     if (fg) root.style.setProperty('--fg', fg.value);
     if (accent) root.style.setProperty('--accent', accent.value);
     if (gradientInput) root.style.setProperty('--gradient', gradientInput.value);
+    if (ctaGradientInput) root.style.setProperty('--cta-gradient', ctaGradientInput.value);
+    if (ctaDepthInput) root.style.setProperty('--cta-depth', ctaDepthInput.value + 'px');
     ['vap1', 'vap2', 'vap3'].forEach(v => {
       const el = form.querySelector(`[name="${v}"]`);
       if (el) root.style.setProperty(`--${v}`, el.value);
+    });
+    [['font_header','--font-header'], ['font_body','--font-body'], ['font_paragraph','--font-paragraph']].forEach(([name, varName]) => {
+      const el = form.querySelector(`[name="${name}"]`);
+      if (el) root.style.setProperty(varName, el.value);
     });
     if (patternToggle && patternToggle.checked) {
       const s = {
@@ -66,6 +74,10 @@ document.addEventListener('DOMContentLoaded', () => {
   form.addEventListener('submit', e => {
     if (gradientInput && gradientInput.value.trim() && !CSS.supports('background', gradientInput.value)) {
       alert('Invalid gradient CSS');
+      e.preventDefault();
+    }
+    if (ctaGradientInput && ctaGradientInput.value.trim() && !CSS.supports('background', ctaGradientInput.value)) {
+      alert('Invalid CTA gradient CSS');
       e.preventDefault();
     }
   });

--- a/assets/style.css
+++ b/assets/style.css
@@ -14,8 +14,12 @@
   --footer-pattern: none;
   --pattern-hue: 0deg;
   --pattern-sat: 100%;
+  --font-header: 'Share Tech Mono', monospace;
+  --font-body: 'Share Tech Mono', monospace;
+  --font-paragraph: 'Share Tech Mono', monospace;
   --btn-depth: 6px;
   --cta-depth: 20px;
+  --cta-gradient: linear-gradient(45deg, var(--accent), var(--vap2), var(--vap3));
 }
 
 [data-theme='dark'] {
@@ -64,12 +68,20 @@ body {
   background-repeat: no-repeat;
   background-size: cover;
   color: var(--fg);
-  font-family: 'Share Tech Mono', monospace;
+  font-family: var(--font-body, 'Share Tech Mono', monospace);
   text-transform: uppercase;
   font-size: 0.85rem;
   margin: 0;
   padding: 1rem;
   padding-bottom: 4rem;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-header, var(--font-body, 'Share Tech Mono', monospace));
+}
+
+p {
+  font-family: var(--font-paragraph, var(--font-body, 'Share Tech Mono', monospace));
 }
 
 body.site-frame {
@@ -193,7 +205,7 @@ body.site-frame {
 }
 
 .btn-cta {
-  background: linear-gradient(45deg, var(--accent), var(--vap2), var(--vap3));
+  background: var(--cta-gradient);
   background-size: 300% 300%;
   color: #fff;
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
@@ -396,6 +408,9 @@ footer:hover {
   align-items: center;
   gap: 0.5rem;
   margin-left: 1rem;
+  padding: 0.25rem 0.5rem;
+  border: 2px solid transparent;
+  border-radius: 4px;
 }
 
 .avatar-sm {
@@ -411,6 +426,39 @@ footer:hover {
   padding: 2px 4px;
   border-radius: 3px;
   margin-left: 4px;
+}
+
+@keyframes statusPulse {
+  0%, 100% {
+    transform: perspective(400px) translateZ(0);
+  }
+  50% {
+    transform: perspective(400px) translateZ(6px);
+  }
+}
+
+.user-display.status-online {
+  border-color: #0f0;
+  box-shadow: 0 0 6px #0f0, inset 0 2px 0 rgba(255, 255, 255, 0.3), inset 0 -2px 0 rgba(0, 0, 0, 0.3);
+  animation: statusPulse 2s infinite;
+}
+
+.user-display.status-busy {
+  border-color: #f00;
+  box-shadow: 0 0 6px #f00, inset 0 2px 0 rgba(255, 255, 255, 0.3), inset 0 -2px 0 rgba(0, 0, 0, 0.3);
+  animation: statusPulse 1.5s infinite;
+}
+
+.user-display.status-away {
+  border-color: #ffa500;
+  box-shadow: 0 0 6px #ffa500, inset 0 2px 0 rgba(255, 255, 255, 0.3), inset 0 -2px 0 rgba(0, 0, 0, 0.3);
+  animation: statusPulse 2.5s infinite;
+}
+
+.user-display.status-offline {
+  border-color: #777;
+  box-shadow: 0 0 6px #777, inset 0 2px 0 rgba(255, 255, 255, 0.3), inset 0 -2px 0 rgba(0, 0, 0, 0.3);
+  animation: statusPulse 4s infinite;
 }
 
 .notice {
@@ -500,9 +548,6 @@ footer:hover {
   padding: 0.5rem;
   border-radius: 4px;
 }
-
-.site-search input {
-  background: var(--bg);
 
 .search-container {
   background: rgba(0, 0, 0, 0.5);

--- a/assets/themes.json
+++ b/assets/themes.json
@@ -5,7 +5,12 @@
       "--bg": "#2d1e59",
       "--fg": "#f8f9fa",
       "--accent": "#ff71ce",
-      "--gradient": "linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)"
+      "--gradient": "linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)",
+      "--font-header": "'Share Tech Mono', monospace",
+      "--font-body": "'Share Tech Mono', monospace",
+      "--font-paragraph": "'Share Tech Mono', monospace",
+      "--cta-gradient": "linear-gradient(45deg, var(--accent), var(--fg))",
+      "--cta-depth": "20px"
     }
   },
   "dark": {
@@ -14,7 +19,12 @@
       "--bg": "#1b1135",
       "--fg": "#e0d9f6",
       "--accent": "#01cdfe",
-      "--gradient": "linear-gradient(135deg, #2d1e59 0%, #09002e 100%)"
+      "--gradient": "linear-gradient(135deg, #2d1e59 0%, #09002e 100%)",
+      "--font-header": "'Share Tech Mono', monospace",
+      "--font-body": "'Share Tech Mono', monospace",
+      "--font-paragraph": "'Share Tech Mono', monospace",
+      "--cta-gradient": "linear-gradient(45deg, var(--accent), var(--fg))",
+      "--cta-depth": "20px"
     }
   },
   "vaporwave": {
@@ -26,7 +36,12 @@
       "--gradient": "linear-gradient(-45deg, var(--vap1), var(--vap2), var(--vap3), var(--vap1))",
       "--vap1": "#ff71ce",
       "--vap2": "#01cdfe",
-      "--vap3": "#05ffa1"
+      "--vap3": "#05ffa1",
+      "--font-header": "'Share Tech Mono', monospace",
+      "--font-body": "'Share Tech Mono', monospace",
+      "--font-paragraph": "'Share Tech Mono', monospace",
+      "--cta-gradient": "linear-gradient(45deg, var(--vap1), var(--vap2), var(--vap3))",
+      "--cta-depth": "20px"
     },
     "pattern": {
       "frequency": 5,
@@ -42,7 +57,12 @@
       "--bg": "#ffe4e1",
       "--fg": "#333333",
       "--accent": "#ffb6c1",
-      "--gradient": "linear-gradient(135deg, #ffe4e1 0%, #e0ffff 100%)"
+      "--gradient": "linear-gradient(135deg, #ffe4e1 0%, #e0ffff 100%)",
+      "--font-header": "'Share Tech Mono', monospace",
+      "--font-body": "'Share Tech Mono', monospace",
+      "--font-paragraph": "'Share Tech Mono', monospace",
+      "--cta-gradient": "linear-gradient(45deg, var(--accent), var(--fg))",
+      "--cta-depth": "20px"
     }
   },
   "forest": {
@@ -51,7 +71,12 @@
       "--bg": "#2e3d2f",
       "--fg": "#e6e8e6",
       "--accent": "#4caf50",
-      "--gradient": "linear-gradient(135deg, #2e3d2f 0%, #1b2c20 100%)"
+      "--gradient": "linear-gradient(135deg, #2e3d2f 0%, #1b2c20 100%)",
+      "--font-header": "'Share Tech Mono', monospace",
+      "--font-body": "'Share Tech Mono', monospace",
+      "--font-paragraph": "'Share Tech Mono', monospace",
+      "--cta-gradient": "linear-gradient(45deg, var(--accent), var(--fg))",
+      "--cta-depth": "20px"
     }
   },
   "borders": {

--- a/includes/user.php
+++ b/includes/user.php
@@ -2,15 +2,17 @@
 function username_with_avatar(mysqli $conn, int $user_id, ?string $username = null): string {
     $vip = 0;
     $vip_expires = null;
-    if ($stmt = $conn->prepare('SELECT username, vip_status, vip_expires_at FROM users WHERE id = ?')) {
+    $status = 'offline';
+    if ($stmt = $conn->prepare('SELECT username, vip_status, vip_expires_at, status FROM users WHERE id = ?')) {
         $stmt->bind_param('i', $user_id);
         $stmt->execute();
-        $stmt->bind_result($usernameFetched, $vip, $vip_expires);
+        $stmt->bind_result($usernameFetched, $vip, $vip_expires, $statusFetched);
         $stmt->fetch();
         $stmt->close();
         if ($username === null) {
             $username = $usernameFetched;
         }
+        $status = $statusFetched;
     }
 
     $avatar = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48Y2lyY2xlIGN4PSI1MCIgY3k9IjUwIiByPSI1MCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg==';
@@ -35,7 +37,13 @@ function username_with_avatar(mysqli $conn, int $user_id, ?string $username = nu
         $badge = ' <span class="vip-badge">VIP</span>';
     }
 
-    return '<span class="user-display"><img src="' . htmlspecialchars($avatar, ENT_QUOTES, 'UTF-8') . '" alt="" class="avatar-sm">' .
+    $allowedStatuses = ['online', 'offline', 'busy', 'away'];
+    if (!in_array($status, $allowedStatuses, true)) {
+        $status = 'offline';
+    }
+
+    return '<span class="user-display status-' . htmlspecialchars($status, ENT_QUOTES, 'UTF-8') . '"><img src="' .
+           htmlspecialchars($avatar, ENT_QUOTES, 'UTF-8') . '" alt="" class="avatar-sm">' .
            htmlspecialchars($username ?? '', ENT_QUOTES, 'UTF-8') . $badge . '</span>';
 }
 ?>


### PR DESCRIPTION
## Summary
- explain pattern application to header and footer
- add tooltips and descriptions for pattern frequency, amplitude, polynomial, hue, and saturation inputs
- include "How it works" paragraph for pattern controls
- support header, body, and paragraph font variables with live preview
- allow CTA button gradient and depth to be theme-driven with live preview
- append status classes to user display elements and style them with animated 3D borders
- document status presets in admin user editor

## Testing
- `php -l admin/theme.php`
- `php -l includes/user.php`
- `php -l admin/user-edit.php`
- `php tests/service_category_flow_test.php`
- `php tests/service_wizard_test.php`
- `php tests/trade_navigation_test.php`
- `npx --yes stylelint assets/style.css --formatter verbose`


------
https://chatgpt.com/codex/tasks/task_e_68b8016b005c832bb8cc55c55d4f19f9