### PR TITLE
Use foreground color for buttons, expand product grid, remove link underlines, fix ASCII art, add ad slot, link user displays to profiles, allow admin post deletions, harden message tools, and make footer sticky

### DIFF
--- a/assets/message-tools.js
+++ b/assets/message-tools.js
@@ -1,25 +1,30 @@
-const textarea = document.querySelector('.message-form textarea');
-if (textarea) {
-  document.querySelectorAll('.message-tools button').forEach(btn => {
-    const format = btn.dataset.format;
-    const insert = btn.dataset.insert;
-    btn.addEventListener('click', () => {
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      const value = textarea.value;
-      if (format === 'bold') {
-        textarea.value = value.slice(0, start) + '**' + value.slice(start, end) + '**' + value.slice(end);
-        textarea.selectionStart = start + 2;
-        textarea.selectionEnd = end + 2;
-      } else if (format === 'italic') {
-        textarea.value = value.slice(0, start) + '*' + value.slice(start, end) + '*' + value.slice(end);
-        textarea.selectionStart = start + 1;
-        textarea.selectionEnd = end + 1;
-      } else if (insert) {
-        textarea.value = value.slice(0, start) + insert + value.slice(end);
-        textarea.selectionStart = textarea.selectionEnd = start + insert.length;
-      }
-      textarea.focus();
+document.addEventListener('DOMContentLoaded', () => {
+  const textarea = document.querySelector('.message-form textarea');
+  if (textarea) {
+    document.querySelectorAll('.message-tools button').forEach(btn => {
+      const format = btn.dataset.format;
+      const insert = btn.dataset.insert;
+      btn.addEventListener('click', () => {
+        if (typeof textarea.selectionStart !== 'number' || typeof textarea.selectionEnd !== 'number') {
+          textarea.focus();
+        }
+        const start = textarea.selectionStart ?? 0;
+        const end = textarea.selectionEnd ?? 0;
+        const value = textarea.value;
+        if (format === 'bold') {
+          textarea.value = value.slice(0, start) + '**' + value.slice(start, end) + '**' + value.slice(end);
+          textarea.selectionStart = start + 2;
+          textarea.selectionEnd = end + 2;
+        } else if (format === 'italic') {
+          textarea.value = value.slice(0, start) + '*' + value.slice(start, end) + '*' + value.slice(end);
+          textarea.selectionStart = start + 1;
+          textarea.selectionEnd = end + 1;
+        } else if (insert) {
+          textarea.value = value.slice(0, start) + insert + value.slice(end);
+          textarea.selectionStart = textarea.selectionEnd = start + insert.length;
+        }
+        textarea.focus();
+      });
     });
-  });
-}
+  }
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -95,6 +95,9 @@ body {
   font-size: var(--font-size-base);
   margin: 0;
   padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -107,6 +110,7 @@ p {
 
 a {
   color: var(--accent);
+  text-decoration: none;
 }
 
 a:visited {
@@ -116,6 +120,7 @@ a:visited {
 a:hover,
 a:focus {
   color: var(--fg);
+  text-decoration: none;
 }
 .card {
   background: rgba(0, 0, 0, 0.4);
@@ -327,6 +332,7 @@ footer {
   box-sizing: border-box;
   transform: perspective(500px) translateZ(0);
   transition: transform 0.2s, box-shadow 0.2s;
+  margin-top: auto;
 }
 
 footer::before {
@@ -532,7 +538,12 @@ footer:focus-within {
 }
 
 .header-left {
-  justify-content: space-between;
+  justify-content: flex-start;
+  gap: var(--space-sm);
+}
+
+.logo-link {
+  margin-right: var(--space-sm);
 }
 
 .header-center {
@@ -541,7 +552,7 @@ footer:focus-within {
 
 .header-right {
   justify-content: flex-end;
-  gap: var(--space-sm);
+  gap: var(--space-md);
 }
 
 .header-user,
@@ -754,7 +765,7 @@ form button:active {
 
 .btn {
   background: var(--accent);
-  color: var(--bg);
+  color: var(--fg);
   margin-right: var(--space-sm);
   border-top: 2px solid rgba(255, 255, 255, 0.4);
   border-left: 2px solid rgba(255, 255, 255, 0.4);
@@ -984,6 +995,9 @@ tbody tr:nth-child(even) {
 .filters {
   max-width: 200px;
 }
+.listing-results {
+  flex: 1;
+}
 .listing-toolbar {
   display: flex;
   justify-content: space-between;
@@ -1012,6 +1026,12 @@ tbody tr:nth-child(even) {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+@media (min-width: 800px) {
+  .product-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 .product-grid.list-view {
   display: block;
@@ -1237,7 +1257,7 @@ body.nav-open .hero {
   border: 1px solid var(--fg);
   padding: 0.5rem;
   border-radius: 4px;
-  background: rgba(0, 0, 0, 0.2);
+  background: color-mix(in srgb, var(--bg) 90%, #000 10%);
   max-width: 70%;
   width: fit-content;
   margin-right: auto;
@@ -1388,3 +1408,16 @@ body.nav-open .hero {
     transform: none;
   }
 }
+
+.ad-slot {
+  width: 100%;
+  max-width: 728px;
+  height: 90px;
+  margin: var(--space-md) auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.15);
+  border: 1px dashed var(--fg);
+}
+

--- a/buy.php
+++ b/buy.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require 'includes/db.php';
+require 'includes/csrf.php';
 
 $search = trim($_GET['search'] ?? '');
 $category = trim($_GET['category'] ?? '');
@@ -133,6 +134,14 @@ $stmt->close();
             <p class="price">$<?= htmlspecialchars($l['price']) ?></p>
             <div class="rating">★★★★★</div>
             <button class="add-to-cart" data-id="<?= $l['id'] ?>">Add to Cart</button>
+            <?php if (!empty($_SESSION['is_admin'])): ?>
+              <form method="post" action="listing-delete.php" onsubmit="return confirm('Delete listing?');">
+                <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+                <input type="hidden" name="id" value="<?= $l['id']; ?>">
+                <input type="hidden" name="redirect" value="<?= htmlspecialchars($_SERVER['REQUEST_URI']); ?>">
+                <button type="submit" class="btn">Delete</button>
+              </form>
+            <?php endif; ?>
           </div>
         <?php endforeach; ?>
         </div>

--- a/friend-search.php
+++ b/friend-search.php
@@ -84,7 +84,7 @@ unset($user);
   </form>
   <?php foreach ($results as $user): ?>
     <div class="card">
-      <a href="view-profile.php?id=<?= $user['id']; ?>"><?= username_with_avatar($conn, $user['id'], $user['username']); ?></a>
+      <?= username_with_avatar($conn, $user['id'], $user['username']); ?>
       <?php if ($user['out_status'] === 'pending'): ?>
         <button type="button" class="btn" disabled>Request Sent</button>
       <?php elseif ($user['in_status'] === 'pending'): ?>

--- a/includes/ad-slot.php
+++ b/includes/ad-slot.php
@@ -1,0 +1,1 @@
+<div class="ad-slot"></div>

--- a/includes/header.php
+++ b/includes/header.php
@@ -95,6 +95,7 @@ endif;
     <button class="header-theme" id="theme-toggle" type="button" aria-haspopup="dialog" aria-controls="theme-modal">Themes</button>
   </div>
 </header>
+<?php include __DIR__ . '/ad-slot.php'; ?>
 <div id="theme-modal" class="theme-modal" role="dialog" aria-modal="true" aria-labelledby="theme-modal-title" hidden tabindex="-1">
   <div class="modal-content">
     <h2 id="theme-modal-title">Select Theme</h2>

--- a/includes/user.php
+++ b/includes/user.php
@@ -18,10 +18,11 @@ function username_with_avatar(mysqli $conn, int $user_id, ?string $username = nu
     $avatar = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48Y2lyY2xlIGN4PSI1MCIgY3k9IjUwIiByPSI1MCIgZmlsbD0iI2NjYyIvPjwvc3ZnPg==';
     $avatarDir = __DIR__ . '/../assets/avatars/';
     $avatarBase = '/assets/avatars/';
-    if ($stmt = $conn->prepare('SELECT avatar_path FROM profiles WHERE user_id = ?')) {
+    $isPrivate = 0;
+    if ($stmt = $conn->prepare('SELECT avatar_path, is_private FROM profiles WHERE user_id = ?')) {
         $stmt->bind_param('i', $user_id);
         $stmt->execute();
-        $stmt->bind_result($path);
+        $stmt->bind_result($path, $isPrivate);
         if ($stmt->fetch() && $path) {
             $file = basename($path);
             $fullPath = $avatarDir . $file;
@@ -42,8 +43,32 @@ function username_with_avatar(mysqli $conn, int $user_id, ?string $username = nu
         $status = 'offline';
     }
 
-    return '<span class="user-display status-' . htmlspecialchars($status, ENT_QUOTES, 'UTF-8') . '"><img src="' .
-           htmlspecialchars($avatar, ENT_QUOTES, 'UTF-8') . '" alt="" class="avatar-sm">' .
-           htmlspecialchars($username ?? '', ENT_QUOTES, 'UTF-8') . $badge . '</span>';
+    $display = '<span class="user-display status-' . htmlspecialchars($status, ENT_QUOTES, 'UTF-8') . '"><img src="' .
+               htmlspecialchars($avatar, ENT_QUOTES, 'UTF-8') . '" alt="" class="avatar-sm">' .
+               htmlspecialchars($username ?? '', ENT_QUOTES, 'UTF-8') . $badge . '</span>';
+
+    $link = '<a href="view-profile.php?id=' . intval($user_id) . '">' . $display . '</a>';
+
+    $privacyNote = '';
+    if ($isPrivate) {
+        $viewer = $_SESSION['user_id'] ?? 0;
+        $isFriend = false;
+        if ($viewer === $user_id) {
+            $isFriend = true;
+        } elseif ($viewer) {
+            if ($stmt = $conn->prepare('SELECT 1 FROM friends WHERE ((user_id=? AND friend_id=?) OR (user_id=? AND friend_id=?)) AND status="accepted" LIMIT 1')) {
+                $stmt->bind_param('iiii', $user_id, $viewer, $viewer, $user_id);
+                $stmt->execute();
+                $stmt->store_result();
+                $isFriend = $stmt->num_rows === 1;
+                $stmt->close();
+            }
+        }
+        if (!$isFriend) {
+            $privacyNote = ' <span class="private-note">🔒 Private – friends only.</span>';
+        }
+    }
+
+    return $link . $privacyNote;
 }
 ?>

--- a/index.php
+++ b/index.php
@@ -16,12 +16,12 @@ session_start();
     <div class="hero">
       <div class="hero-ascii">
         <pre>
-____  _              _____
+ ____  _              _____
 / ___|| | ___   _ ___| ____|
 \___ \| |/ / | | |_  /  _|
  ___) |   <| |_| |/ /| |___
-|____/|_|\\__,_/___|_____|
-</pre>
+|____/|_|\__,_/___|_____|
+        </pre>
       </div>
       <div class="hero-content">
         <p class="tagline">Fix, buy, sell, or trade your electronics in one place.</p>

--- a/listing-delete.php
+++ b/listing-delete.php
@@ -1,0 +1,19 @@
+<?php
+session_start();
+require 'includes/db.php';
+require 'includes/csrf.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && validate_token($_POST['csrf_token'] ?? '') && (!empty($_SESSION['is_admin']))) {
+    $id = intval($_POST['id'] ?? 0);
+    if ($id) {
+        if ($stmt = $conn->prepare('DELETE FROM listings WHERE id = ?')) {
+            $stmt->bind_param('i', $id);
+            $stmt->execute();
+            $stmt->close();
+        }
+    }
+}
+$redirect = $_POST['redirect'] ?? 'buy.php';
+header('Location: ' . $redirect);
+exit;
+?>

--- a/listing.php
+++ b/listing.php
@@ -1,5 +1,7 @@
 <?php
+session_start();
 require 'includes/db.php';
+require 'includes/csrf.php';
 
 $listing_id = isset($_GET['listing_id']) ? intval($_GET['listing_id']) : 0;
 if (!$listing_id) {
@@ -49,6 +51,14 @@ if (!$listing) {
           <a href="search.php?category=<?= urlencode($listing['category']); ?>">More in this category</a>
         </p>
       </div>
+      <?php if (!empty($_SESSION['is_admin'])): ?>
+        <form method="post" action="listing-delete.php" onsubmit="return confirm('Delete listing?');">
+          <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+          <input type="hidden" name="id" value="<?= $listing['id']; ?>">
+          <input type="hidden" name="redirect" value="buy.php">
+          <button type="submit" class="btn">Delete Listing</button>
+        </form>
+      <?php endif; ?>
     </section>
   </div>
   <?php include 'includes/footer.php'; ?>

--- a/trade-listing-delete.php
+++ b/trade-listing-delete.php
@@ -1,0 +1,32 @@
+<?php
+session_start();
+require 'includes/db.php';
+require 'includes/csrf.php';
+
+$user_id = $_SESSION['user_id'] ?? null;
+$is_admin = !empty($_SESSION['is_admin']);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && validate_token($_POST['csrf_token'] ?? '')) {
+    $id = intval($_POST['id'] ?? 0);
+    if ($id) {
+        $owner_id = null;
+        if ($stmt = $conn->prepare('SELECT owner_id FROM trade_listings WHERE id = ?')) {
+            $stmt->bind_param('i', $id);
+            $stmt->execute();
+            $stmt->bind_result($owner_id);
+            $stmt->fetch();
+            $stmt->close();
+        }
+        if ($is_admin || ($owner_id !== null && $owner_id == $user_id)) {
+            if ($stmt = $conn->prepare('DELETE FROM trade_listings WHERE id = ?')) {
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->close();
+            }
+        }
+    }
+}
+$redirect = $_POST['redirect'] ?? 'trade-listings.php';
+header('Location: ' . $redirect);
+exit;
+?>

--- a/trade-offer-delete.php
+++ b/trade-offer-delete.php
@@ -1,0 +1,19 @@
+<?php
+session_start();
+require 'includes/db.php';
+require 'includes/csrf.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && validate_token($_POST['csrf_token'] ?? '') && !empty($_SESSION['is_admin'])) {
+    $id = intval($_POST['id'] ?? 0);
+    if ($id) {
+        if ($stmt = $conn->prepare('DELETE FROM trade_offers WHERE id = ?')) {
+            $stmt->bind_param('i', $id);
+            $stmt->execute();
+            $stmt->close();
+        }
+    }
+}
+$redirect = $_POST['redirect'] ?? 'trade.php';
+header('Location: ' . $redirect);
+exit;
+?>

--- a/trade.php
+++ b/trade.php
@@ -110,6 +110,14 @@ if ($listing_filter) {
                   <button name="action" value="decline" type="submit">Decline</button>
                 </form>
               <?php endif; ?>
+              <?php if (!empty($_SESSION['is_admin'])): ?>
+                <form method="post" action="trade-offer-delete.php" style="display:inline" onsubmit="return confirm('Delete offer?');">
+                  <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+                  <input type="hidden" name="id" value="<?= $o['id']; ?>">
+                  <input type="hidden" name="redirect" value="trade.php?listing=<?= $listing_filter ?>">
+                  <button type="submit">Delete</button>
+                </form>
+              <?php endif; ?>
             </td>
           <?php else: ?>
             <td><?= htmlspecialchars($o['have_item']) ?>/<?= htmlspecialchars($o['want_item']) ?></td>
@@ -124,6 +132,14 @@ if ($listing_filter) {
                   <input type="hidden" name="offer_id" value="<?= $o['id'] ?>">
                   <button name="action" value="accept" type="submit">Accept</button>
                   <button name="action" value="decline" type="submit">Decline</button>
+                </form>
+              <?php endif; ?>
+              <?php if (!empty($_SESSION['is_admin'])): ?>
+                <form method="post" action="trade-offer-delete.php" style="display:inline" onsubmit="return confirm('Delete offer?');">
+                  <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+                  <input type="hidden" name="id" value="<?= $o['id']; ?>">
+                  <input type="hidden" name="redirect" value="trade.php">
+                  <button type="submit">Delete</button>
                 </form>
               <?php endif; ?>
             </td>


### PR DESCRIPTION
## Summary
- ensure button text uses the foreground color and stays free of underline, overriding global link styling
- let product listings flex to fill available space and show four columns on wide screens
- add spacing so the logo, navigation, and language/theme buttons no longer crowd each other
- remove default underlines from links, relying on color and background to signal interactivity
- correct the homepage hero with properly spaced SkuzE ASCII art
- add a site-wide ad slot placeholder after the header and style it for standard banner dimensions
- wrap user displays in profile links and show a lock notice when viewing a private profile without friendship
- allow administrators to delete listings and trade posts via CSRF-protected forms
- darken message bubbles and safeguard rich‑text insertion by focusing the textarea when needed and initializing after DOM load
- wrap page content in a flex container so the footer sticks to the bottom of the viewport

## Testing
- `for f in tests/*_test.php; do php $f; done`
- `npx -y playwright test tests/visual.spec.js` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_68ba74fcad38832b8f94d8ba5cf887af