### PR TITLE
Add support ticket workflow

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -42,6 +42,7 @@ $requests = $stmt->fetch_all(MYSQLI_ASSOC);
         <li><a class="btn" href="users.php">Manage Users</a></li>
         <li><a class="btn" href="theme.php">Vaporwave Theme Settings</a></li>
         <li><a class="btn" href="toolbox.php">Manage Toolbox</a></li>
+        <li><a class="btn" href="support.php">Support Tickets</a></li>
       </ul>
     </div>
   </div>

--- a/admin/order.php
+++ b/admin/order.php
@@ -1,0 +1,101 @@
+<?php
+require '../includes/auth.php';
+require '../includes/orders.php';
+
+if (empty($_SESSION['is_admin'])) {
+    header('Location: ../dashboard.php');
+    exit;
+}
+
+$orderId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($orderId <= 0) {
+    http_response_code(404);
+    $order = null;
+} else {
+    $order = fetch_order_detail_for_admin($conn, $orderId, (int) $_SESSION['user_id']);
+    if (!$order) {
+        http_response_code(404);
+    }
+}
+
+$amountDisplay = '—';
+$paymentStatus = 'pending';
+$shippingStatus = 'pending';
+$badgeClass = 'badge-community';
+$badgeLabel = 'Community Listing';
+if ($order) {
+    $amount = $order['payment']['amount'] ?? null;
+    if ($amount !== null) {
+        $amountDisplay = '$' . number_format(((int) $amount) / 100, 2);
+    }
+    $paymentStatus = $order['payment']['status'] ?? 'pending';
+    $shippingStatus = $order['shipping_status'] ?? 'pending';
+    $isOfficial = $order['product']['is_official'] ?? false;
+    $badgeClass = $isOfficial ? 'badge-official' : 'badge-community';
+    $badgeLabel = $isOfficial ? 'Official SkuzE' : 'Community Listing';
+}
+?>
+<?php require '../includes/layout.php'; ?>
+  <title>Admin · Order <?= $order ? '#' . htmlspecialchars((string) $order['id'], ENT_QUOTES, 'UTF-8') : '' ?></title>
+  <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+  <?php include '../includes/header.php'; ?>
+  <div class="page-container order-detail">
+    <h2>Order Review</h2>
+    <p><a class="btn" href="orders.php">← Back to Orders</a></p>
+    <?php if (!$order): ?>
+      <p class="notice">Order not found.</p>
+    <?php else: ?>
+      <section class="order-summary">
+        <h3>Summary</h3>
+        <ul>
+          <li><strong>Order ID:</strong> #<?= (int) $order['id'] ?></li>
+          <li><strong>Placed:</strong> <?= htmlspecialchars($order['placed_at'], ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Direction:</strong> <?= htmlspecialchars(ucfirst($order['direction']), ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Buyer:</strong> <?= htmlspecialchars($order['buyer']['username'] ?? '—', ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Seller:</strong> <?= htmlspecialchars($order['listing']['owner_username'] ?? '—', ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Listing:</strong> <a href="../listing.php?id=<?= (int) $order['listing']['id'] ?>"><?= htmlspecialchars($order['listing']['title'], ENT_QUOTES, 'UTF-8') ?></a></li>
+          <li><strong>Inventory Remaining:</strong> <?= (int) $order['product']['quantity'] ?></li>
+          <li><strong>Reorder Threshold:</strong> <?= (int) $order['product']['reorder_threshold'] ?></li>
+        </ul>
+      </section>
+      <section class="order-product">
+        <h3>Product</h3>
+        <p><span class="badge <?= htmlspecialchars($badgeClass, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($badgeLabel, ENT_QUOTES, 'UTF-8') ?></span></p>
+        <ul>
+          <li><strong>Title:</strong> <?= htmlspecialchars($order['product']['title'] ?: $order['listing']['title'], ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>SKU:</strong> <?= htmlspecialchars($order['product']['sku'], ENT_QUOTES, 'UTF-8') ?></li>
+        </ul>
+      </section>
+      <section class="order-payment">
+        <h3>Payment</h3>
+        <ul>
+          <li><strong>Amount:</strong> <?= htmlspecialchars($amountDisplay, ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Status:</strong> <?= htmlspecialchars(ucfirst($paymentStatus ?? 'pending'), ENT_QUOTES, 'UTF-8') ?></li>
+          <?php if (!empty($order['payment']['reference'])): ?>
+          <li><strong>Reference:</strong> <?= htmlspecialchars($order['payment']['reference'], ENT_QUOTES, 'UTF-8') ?></li>
+          <?php endif; ?>
+          <?php if (!empty($order['payment']['created_at'])): ?>
+          <li><strong>Captured:</strong> <?= htmlspecialchars($order['payment']['created_at'], ENT_QUOTES, 'UTF-8') ?></li>
+          <?php endif; ?>
+        </ul>
+      </section>
+      <section class="order-shipping">
+        <h3>Fulfillment</h3>
+        <ul>
+          <li><strong>Delivery method:</strong> <?= htmlspecialchars($order['delivery_method'] ?? '—', ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Shipping status:</strong> <?= htmlspecialchars(ucfirst($shippingStatus), ENT_QUOTES, 'UTF-8') ?></li>
+          <?php if (!empty($order['tracking_number'])): ?>
+          <li><strong>Tracking number:</strong> <?= htmlspecialchars($order['tracking_number'], ENT_QUOTES, 'UTF-8') ?></li>
+          <?php endif; ?>
+          <?php if (!empty($order['notes'])): ?>
+          <li><strong>Notes:</strong> <?= nl2br(htmlspecialchars($order['notes'], ENT_QUOTES, 'UTF-8')) ?></li>
+          <?php endif; ?>
+        </ul>
+      </section>
+    <?php endif; ?>
+  </div>
+  <?php include '../includes/footer.php'; ?>
+</body>
+</html>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1,36 +1,99 @@
 <?php
 require '../includes/auth.php';
+require '../includes/orders.php';
 
-$rows = [];
-if ($stmt = $conn->prepare('SELECT of.id, u.username, of.sku, p.title, p.quantity, p.reorder_threshold, of.status FROM order_fulfillments of JOIN users u ON of.user_id = u.id JOIN products p ON of.sku = p.sku ORDER BY of.created_at DESC')) {
-    $stmt->execute();
-    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
-    $stmt->close();
+if (empty($_SESSION['is_admin'])) {
+    header('Location: ../dashboard.php');
+    exit;
 }
+
+$filter = $_GET['official'] ?? 'all';
+$officialOnly = null;
+if ($filter === 'official') {
+    $officialOnly = true;
+} elseif ($filter === 'community') {
+    $officialOnly = false;
+}
+
+$userId = isset($_SESSION['user_id']) ? (int) $_SESSION['user_id'] : 0;
+$orders = fetch_orders_for_admin($conn, $officialOnly, $userId);
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Admin - Order Fulfillments</title>
-    <link rel="stylesheet" href="../assets/style.css">
+<?php require '../includes/layout.php'; ?>
+  <title>Admin - Orders</title>
+  <link rel="stylesheet" href="../assets/style.css">
 </head>
 <body>
-<h1>Order Fulfillments</h1>
-<p><a href="products.php">Manage Products</a></p>
-<table border="1" cellpadding="5">
-    <tr><th>ID</th><th>User</th><th>SKU</th><th>Product</th><th>Remaining Stock</th><th>Threshold</th><th>Shipment Status</th></tr>
-    <?php foreach ($rows as $row): ?>
-    <tr>
-        <td><?= $row['id'] ?></td>
-        <td><?= htmlspecialchars($row['username']) ?></td>
-        <td><?= htmlspecialchars($row['sku']) ?></td>
-        <td><?= htmlspecialchars($row['title']) ?></td>
-        <td><?= (int)$row['quantity'] ?></td>
-        <td><?= (int)$row['reorder_threshold'] ?></td>
-        <td><?= htmlspecialchars($row['status']) ?></td>
-    </tr>
-    <?php endforeach; ?>
-</table>
+  <?php include '../includes/header.php'; ?>
+  <div class="page-container">
+    <h1>Orders</h1>
+    <form method="get" class="filter-form">
+      <label for="official">Inventory:</label>
+      <select id="official" name="official" onchange="this.form.submit()">
+        <option value="all" <?= $filter === 'all' ? 'selected' : '' ?>>All</option>
+        <option value="official" <?= $filter === 'official' ? 'selected' : '' ?>>Official only</option>
+        <option value="community" <?= $filter === 'community' ? 'selected' : '' ?>>Community only</option>
+      </select>
+      <noscript><button type="submit">Apply</button></noscript>
+    </form>
+    <?php if ($orders): ?>
+    <table class="orders-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Direction</th>
+          <th>Product</th>
+          <th>Official</th>
+          <th>Inventory</th>
+          <th>Buyer</th>
+          <th>Seller</th>
+          <th>Payment</th>
+          <th>Shipping</th>
+          <th>Placed</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+      <?php foreach ($orders as $order): ?>
+        <?php
+          $isOfficial = $order['product']['is_official'];
+          $badgeClass = $isOfficial ? 'badge-official' : 'badge-community';
+          $badgeLabel = $isOfficial ? 'Official' : 'Community';
+          $amount = $order['payment']['amount'];
+          $amountDisplay = $amount !== null ? '$' . number_format(((int) $amount) / 100, 2) : '—';
+          $paymentStatus = $order['payment']['status'] ?? 'pending';
+          $shippingStatus = $order['shipping_status'] ?? 'pending';
+        ?>
+        <tr>
+          <td>#<?= (int) $order['id'] ?></td>
+          <td class="order-direction order-direction-<?= htmlspecialchars($order['direction'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars(ucfirst($order['direction']), ENT_QUOTES, 'UTF-8') ?></td>
+          <td>
+            <strong><?= htmlspecialchars($order['product']['title'] ?: $order['listing']['title'], ENT_QUOTES, 'UTF-8') ?></strong><br>
+            <small><?= htmlspecialchars($order['product']['sku'], ENT_QUOTES, 'UTF-8') ?></small>
+          </td>
+          <td><span class="badge <?= htmlspecialchars($badgeClass, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($badgeLabel, ENT_QUOTES, 'UTF-8') ?></span></td>
+          <td><?= (int) $order['product']['quantity'] ?></td>
+          <td><?= htmlspecialchars($order['buyer']['username'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+          <td><?= htmlspecialchars($order['listing']['owner_username'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+          <td>
+            <?= htmlspecialchars($amountDisplay, ENT_QUOTES, 'UTF-8') ?><br>
+            <small>Status: <?= htmlspecialchars(ucfirst($paymentStatus ?? 'pending'), ENT_QUOTES, 'UTF-8') ?></small>
+          </td>
+          <td>
+            <?= htmlspecialchars(ucfirst($shippingStatus), ENT_QUOTES, 'UTF-8') ?>
+            <?php if (!empty($order['tracking_number'])): ?>
+              <br><small>Tracking: <?= htmlspecialchars($order['tracking_number'], ENT_QUOTES, 'UTF-8') ?></small>
+            <?php endif; ?>
+          </td>
+          <td><?= htmlspecialchars($order['placed_at'], ENT_QUOTES, 'UTF-8') ?></td>
+          <td><a href="order.php?id=<?= (int) $order['id'] ?>">Inspect</a></td>
+        </tr>
+      <?php endforeach; ?>
+      </tbody>
+    </table>
+    <?php else: ?>
+    <p>No orders found for the selected filter.</p>
+    <?php endif; ?>
+  </div>
+  <?php include '../includes/footer.php'; ?>
 </body>
 </html>

--- a/admin/support.php
+++ b/admin/support.php
@@ -1,0 +1,136 @@
+<?php
+require '../includes/auth.php';
+require '../includes/db.php';
+require '../includes/csrf.php';
+require '../includes/support.php';
+require '../includes/user.php';
+
+if (empty($_SESSION['is_admin'])) {
+    header('Location: ../dashboard.php');
+    exit;
+}
+
+$statusFilter = $_GET['status'] ?? null;
+$allowedStatuses = ['open', 'pending', 'closed'];
+if ($statusFilter && !in_array($statusFilter, $allowedStatuses, true)) {
+    $statusFilter = null;
+}
+
+$message = '';
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_token($_POST['csrf_token'] ?? '')) {
+        $error = 'Invalid CSRF token.';
+    } else {
+        $ticket_id = isset($_POST['ticket_id']) ? (int) $_POST['ticket_id'] : 0;
+        $status = $_POST['status'] ?? 'open';
+        $assigned_to = isset($_POST['assigned_to']) && $_POST['assigned_to'] !== '' ? (int) $_POST['assigned_to'] : null;
+        $assign_to_me = isset($_POST['assign_to_me']);
+
+        if ($ticket_id <= 0) {
+            $error = 'Invalid ticket selected.';
+        } else {
+            if ($assign_to_me) {
+                $assigned_to = (int) $_SESSION['user_id'];
+            }
+            try {
+                if (update_support_ticket($conn, $ticket_id, $status, $assigned_to)) {
+                    $message = 'Ticket updated successfully.';
+                } else {
+                    $error = 'Failed to update the ticket.';
+                }
+            } catch (InvalidArgumentException $e) {
+                $error = $e->getMessage();
+            }
+        }
+    }
+}
+
+$tickets = get_support_tickets($conn, $statusFilter);
+$admins = get_support_admins($conn);
+?>
+<?php require '../includes/layout.php'; ?>
+  <title>Support Tickets</title>
+  <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+  <?php include '../includes/header.php'; ?>
+  <div class="page-container">
+    <h2>Support Tickets</h2>
+    <p><a class="btn" href="index.php">&larr; Back to Admin Panel</a></p>
+    <form method="get" class="support-filter">
+      <label for="status-filter">Status:</label>
+      <select id="status-filter" name="status">
+        <option value=""<?= $statusFilter === null ? ' selected' : ''; ?>>All</option>
+        <?php foreach ($allowedStatuses as $statusOption): ?>
+          <option value="<?= $statusOption; ?>"<?= $statusFilter === $statusOption ? ' selected' : ''; ?>><?= ucfirst($statusOption); ?></option>
+        <?php endforeach; ?>
+      </select>
+      <button type="submit" class="btn">Apply</button>
+    </form>
+
+    <?php if ($message): ?>
+      <div class="alert success"><?= htmlspecialchars($message, ENT_QUOTES, 'UTF-8'); ?></div>
+    <?php elseif ($error): ?>
+      <div class="alert error" role="alert"><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div>
+    <?php endif; ?>
+
+    <?php if (empty($tickets)): ?>
+      <p>No support tickets found.</p>
+    <?php else: ?>
+      <table class="support-ticket-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Subject</th>
+            <th>User</th>
+            <th>Status</th>
+            <th>Assigned</th>
+            <th>Last Update</th>
+            <th>Needs Reply</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($tickets as $ticket): ?>
+          <?php $formId = 'ticket-form-' . (int) $ticket['id']; ?>
+          <tr>
+            <td>#<?= (int) $ticket['id']; ?></td>
+            <td><?= htmlspecialchars($ticket['subject'], ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?= username_with_avatar($conn, (int) $ticket['user_id'], $ticket['user_username']); ?></td>
+            <td>
+              <select name="status" form="<?= $formId; ?>">
+                <?php foreach ($allowedStatuses as $statusOption): ?>
+                  <option value="<?= $statusOption; ?>"<?= $ticket['status'] === $statusOption ? ' selected' : ''; ?>><?= ucfirst($statusOption); ?></option>
+                <?php endforeach; ?>
+              </select>
+            </td>
+            <td>
+              <select name="assigned_to" form="<?= $formId; ?>">
+                <option value="">Unassigned</option>
+                <?php foreach ($admins as $admin): ?>
+                  <option value="<?= (int) $admin['id']; ?>"<?= ((int) $ticket['assigned_to'] === (int) $admin['id']) ? ' selected' : ''; ?>><?= htmlspecialchars($admin['username'], ENT_QUOTES, 'UTF-8'); ?></option>
+                <?php endforeach; ?>
+              </select>
+            </td>
+            <td><?= htmlspecialchars($ticket['last_message_at'] ?? $ticket['updated_at'], ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?= !empty($ticket['unread_flag']) ? '<span class="badge">New</span>' : '—'; ?></td>
+            <td>
+              <form id="<?= $formId; ?>" method="post" class="support-update-form">
+                <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+                <input type="hidden" name="ticket_id" value="<?= (int) $ticket['id']; ?>">
+                <button type="submit" class="btn">Save</button>
+                <button type="submit" name="assign_to_me" value="1" class="btn btn-secondary">Assign to Me</button>
+              </form>
+              <a class="btn" href="../message-thread.php?user=<?= (int) $ticket['user_id']; ?>">View Messages</a>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+        </tbody>
+      </table>
+    <?php endif; ?>
+  </div>
+  <?php include '../includes/footer.php'; ?>
+</body>
+</html>

--- a/admin/theme.php
+++ b/admin/theme.php
@@ -6,6 +6,31 @@ if (!$_SESSION['is_admin']) {
   exit;
 }
 
+function sanitize_color_input(?string $value, string $fallback): string {
+  $value = trim((string)$value);
+  if ($value === '') {
+    return $fallback;
+  }
+  if (preg_match('/^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i', $value)) {
+    return strtolower($value);
+  }
+  return $fallback;
+}
+
+function clamp_numeric($value, float $min, float $max, float $default = 0.0): float {
+  if (!is_numeric($value)) {
+    return $default;
+  }
+  $value = (float)$value;
+  if ($value < $min) {
+    return $min;
+  }
+  if ($value > $max) {
+    return $max;
+  }
+  return $value;
+}
+
 $themesFile = __DIR__ . '/../assets/themes.json';
 $themes = [];
 if (file_exists($themesFile)) {
@@ -21,39 +46,108 @@ $gradientPresets = [
   'pastel'  => 'linear-gradient(135deg, #ff9a9e 0%, #fad0c4 100%)',
 ];
 
+$wavePresets = [
+  'gentle' => [
+    'label' => 'Gentle Waves',
+    'frequency' => 2.5,
+    'amplitude' => 6,
+    'poly' => [0],
+    'hue' => 0,
+    'sat' => 85,
+    'features' => [
+      'poly' => false,
+      'hue' => false,
+      'sat' => true,
+    ],
+  ],
+  'balanced' => [
+    'label' => 'Balanced Flow',
+    'frequency' => 4,
+    'amplitude' => 10,
+    'poly' => [0, 6, -4],
+    'hue' => 320,
+    'sat' => 110,
+    'features' => [
+      'poly' => true,
+      'hue' => true,
+      'sat' => true,
+    ],
+  ],
+  'dramatic' => [
+    'label' => 'Dramatic Peaks',
+    'frequency' => 6,
+    'amplitude' => 16,
+    'poly' => [0, 12, -10],
+    'hue' => 280,
+    'sat' => 130,
+    'features' => [
+      'poly' => true,
+      'hue' => true,
+      'sat' => true,
+    ],
+  ],
+];
+
+$patternFeatureLabels = [
+  'poly' => 'Curve warp',
+  'hue' => 'Hue shift',
+  'sat' => 'Saturation boost',
+];
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $name = strtolower(preg_replace('/[^a-z0-9_-]/i', '', $_POST['name'] ?? ''));
   if ($name) {
+    $previous = $themes[$name] ?? null;
+    $previousVars = isset($previous['vars']) && is_array($previous['vars']) ? $previous['vars'] : [];
+    $btnFallback = $previousVars['--btn-text'] ?? '#111827';
     $themes[$name] = [
       'label' => $_POST['label'] ?: ucfirst($name),
       'vars' => [
-        '--bg' => $_POST['bg'] ?? '#ffffff',
-        '--fg' => $_POST['fg'] ?? '#000000',
-        '--accent' => $_POST['accent'] ?? '#ff71ce',
-        '--gradient' => $_POST['gradient'] ?? 'linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)',
-        '--vap1' => $_POST['vap1'] ?? null,
-        '--vap2' => $_POST['vap2'] ?? null,
-        '--vap3' => $_POST['vap3'] ?? null,
-        '--font-header' => $_POST['font_header'] ?? "'Share Tech Mono', monospace",
-        '--font-body' => $_POST['font_body'] ?? "'Share Tech Mono', monospace",
-        '--font-paragraph' => $_POST['font_paragraph'] ?? "'Share Tech Mono', monospace",
-        '--cta-gradient' => $_POST['cta_gradient'] ?? 'linear-gradient(45deg, var(--accent), var(--vap2), var(--vap3))',
-        '--cta-depth' => isset($_POST['cta_depth']) && $_POST['cta_depth'] !== '' ? $_POST['cta_depth'] . 'px' : '20px',
+        '--bg' => sanitize_color_input($_POST['bg'] ?? '', $previousVars['--bg'] ?? '#ffffff'),
+        '--fg' => sanitize_color_input($_POST['fg'] ?? '', $previousVars['--fg'] ?? '#000000'),
+        '--accent' => sanitize_color_input($_POST['accent'] ?? '', $previousVars['--accent'] ?? '#ff71ce'),
+        '--btn-text' => sanitize_color_input($_POST['btn_text'] ?? '', $btnFallback),
+        '--gradient' => trim($_POST['gradient'] ?? 'linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)'),
+        '--vap1' => sanitize_color_input($_POST['vap1'] ?? '', $previousVars['--vap1'] ?? '#ff71ce'),
+        '--vap2' => sanitize_color_input($_POST['vap2'] ?? '', $previousVars['--vap2'] ?? '#01cdfe'),
+        '--vap3' => sanitize_color_input($_POST['vap3'] ?? '', $previousVars['--vap3'] ?? '#05ffa1'),
+        '--font-header' => trim($_POST['font_header'] ?? "'Share Tech Mono', monospace"),
+        '--font-body' => trim($_POST['font_body'] ?? "'Share Tech Mono', monospace"),
+        '--font-paragraph' => trim($_POST['font_paragraph'] ?? "'Share Tech Mono', monospace"),
+        '--cta-gradient' => trim($_POST['cta_gradient'] ?? 'linear-gradient(45deg, var(--accent), var(--vap2), var(--vap3))'),
+        '--cta-depth' => clamp_numeric($_POST['cta_depth'] ?? 20, 0, 60, 20) . 'px',
       ],
     ];
     if (!empty($_POST['pattern_enabled'])) {
-      $freq = $_POST['pattern_freq'] ?? '';
-      $amp = $_POST['pattern_amp'] ?? '';
-      $poly = $_POST['pattern_poly'] ?? '';
-      $hue = $_POST['pattern_hue'] ?? '';
-      $sat = $_POST['pattern_sat'] ?? '';
+      $selectedPreset = $_POST['pattern_preset'] ?? 'custom';
+      if (!isset($wavePresets[$selectedPreset])) {
+        $selectedPreset = 'custom';
+      }
+      $featureSelections = [];
+      $rawFeatures = $_POST['pattern_features'] ?? [];
+      if (!is_array($rawFeatures)) {
+        $rawFeatures = [];
+      }
+      foreach ($patternFeatureLabels as $featureKey => $_label) {
+        $featureSelections[$featureKey] = in_array($featureKey, $rawFeatures, true);
+      }
+      $polyInput = $_POST['pattern_poly'] ?? '';
+      $polyCoefficients = array_values(array_filter(array_map('trim', explode(',', $polyInput)), 'strlen'));
+      $polyValues = array_map('floatval', $polyCoefficients);
+      if (empty($featureSelections['poly'])) {
+        $polyValues = [];
+      }
       $themes[$name]['pattern'] = [
-        'frequency' => (float)$freq,
-        'amplitude' => (float)$amp,
-        'poly' => array_map('floatval', array_filter(array_map('trim', explode(',', $poly)), 'strlen')),
-        'hue' => (int)$hue,
-        'sat' => (int)$sat,
+        'preset' => $selectedPreset,
+        'frequency' => clamp_numeric($_POST['pattern_freq'] ?? 0, 0, 10, 0),
+        'amplitude' => clamp_numeric($_POST['pattern_amp'] ?? 0, 0, 20, 0),
+        'poly' => $polyValues,
+        'hue' => $featureSelections['hue'] ? (int)clamp_numeric($_POST['pattern_hue'] ?? 0, 0, 360, 0) : 0,
+        'sat' => $featureSelections['sat'] ? (int)clamp_numeric($_POST['pattern_sat'] ?? 100, 0, 200, 100) : 100,
+        'features' => $featureSelections,
       ];
+    } else {
+      unset($themes[$name]['pattern']);
     }
     $saved = file_put_contents($themesFile, json_encode($themes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     if ($saved !== false) {
@@ -94,6 +188,9 @@ $current = $themes[$edit] ?? null;
     <label>Accent Color
       <input type="color" name="accent" value="<?= htmlspecialchars($current['vars']['--accent'] ?? '#ff71ce', ENT_QUOTES, 'UTF-8'); ?>">
     </label>
+    <label>Button Text Color
+      <input type="color" name="btn_text" value="<?= htmlspecialchars($current['vars']['--btn-text'] ?? '#111827', ENT_QUOTES, 'UTF-8'); ?>">
+    </label>
     <label>Header Font
       <input type="text" name="font_header" value="<?= htmlspecialchars($current['vars']['--font-header'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
     </label>
@@ -129,31 +226,77 @@ $current = $themes[$edit] ?? null;
     <label>Vap Color 3
       <input type="color" name="vap3" value="<?= htmlspecialchars($current['vars']['--vap3'] ?? '#05ffa1', ENT_QUOTES, 'UTF-8'); ?>">
     </label>
-    <label><input type="checkbox" id="pattern_toggle" name="pattern_enabled" <?= isset($current['pattern']) ? 'checked' : ''; ?>> Enable Pattern</label>
-    <div id="pattern_settings" style="display: <?= isset($current['pattern']) ? 'block' : 'none'; ?>;">
+    <?php
+      $currentPattern = isset($current['pattern']) && is_array($current['pattern']) ? $current['pattern'] : null;
+      $currentPreset = 'custom';
+      if ($currentPattern && !empty($currentPattern['preset']) && isset($wavePresets[$currentPattern['preset']])) {
+        $currentPreset = $currentPattern['preset'];
+      }
+      $currentFeatures = [];
+      foreach ($patternFeatureLabels as $featureKey => $_label) {
+        if ($currentPattern && isset($currentPattern['features'][$featureKey])) {
+          $currentFeatures[$featureKey] = (bool)$currentPattern['features'][$featureKey];
+        } elseif ($currentPattern) {
+          if ($featureKey === 'poly') {
+            $currentFeatures[$featureKey] = !empty($currentPattern['poly']);
+          } elseif ($featureKey === 'hue') {
+            $currentFeatures[$featureKey] = !empty($currentPattern['hue']);
+          } elseif ($featureKey === 'sat') {
+            $currentFeatures[$featureKey] = isset($currentPattern['sat']) ? (int)$currentPattern['sat'] !== 100 : false;
+          } else {
+            $currentFeatures[$featureKey] = false;
+          }
+        } else {
+          $currentFeatures[$featureKey] = false;
+        }
+      }
+      $patternPresetsJson = htmlspecialchars(json_encode($wavePresets, JSON_UNESCAPED_SLASHES), ENT_QUOTES, 'UTF-8');
+    ?>
+    <label><input type="checkbox" id="pattern_toggle" name="pattern_enabled" <?= $currentPattern ? 'checked' : ''; ?>> Enable Pattern</label>
+    <div id="pattern_settings" data-presets="<?= $patternPresetsJson; ?>" data-current-preset="<?= htmlspecialchars($currentPreset, ENT_QUOTES, 'UTF-8'); ?>" style="display: <?= $currentPattern ? 'block' : 'none'; ?>;">
       <p class="help-text">The generated pattern is applied to the header and footer backgrounds.</p>
-      <p class="help-text"><strong>How it works:</strong> frequency sets how often the wave repeats, amplitude adjusts the wave height, the polynomial coefficients warp the curve, hue rotates the color, and saturation tweaks the color intensity.</p>
+      <fieldset class="pattern-presets">
+        <legend>Wave Preset</legend>
+        <?php foreach ($wavePresets as $presetKey => $preset): ?>
+          <label class="pattern-preset">
+            <input type="radio" name="pattern_preset" value="<?= htmlspecialchars($presetKey, ENT_QUOTES, 'UTF-8'); ?>" data-settings='<?= htmlspecialchars(json_encode($preset, JSON_UNESCAPED_SLASHES), ENT_QUOTES, 'UTF-8'); ?>' <?= $currentPreset === $presetKey ? 'checked' : ''; ?>>
+            <?= htmlspecialchars($preset['label'], ENT_QUOTES, 'UTF-8'); ?>
+          </label>
+        <?php endforeach; ?>
+        <label class="pattern-preset">
+          <input type="radio" name="pattern_preset" value="custom" <?= $currentPreset === 'custom' ? 'checked' : ''; ?>> Custom
+        </label>
+      </fieldset>
+      <div class="pattern-features">
+        <?php foreach ($patternFeatureLabels as $featureKey => $featureLabel): ?>
+          <label class="pattern-feature">
+            <input type="checkbox" name="pattern_features[]" value="<?= htmlspecialchars($featureKey, ENT_QUOTES, 'UTF-8'); ?>" <?= !empty($currentFeatures[$featureKey]) ? 'checked' : ''; ?>>
+            <?= htmlspecialchars($featureLabel, ENT_QUOTES, 'UTF-8'); ?>
+          </label>
+        <?php endforeach; ?>
+      </div>
+      <p class="help-text"><strong>How it works:</strong> frequency sets how often the wave repeats, amplitude adjusts the wave height, the polynomial coefficients warp the curve when enabled, hue rotates the color, and saturation tweaks the color intensity.</p>
       <label>Pattern Frequency
         <input type="range" min="0" max="10" step="0.1" id="pattern_freq" name="pattern_freq" value="<?= htmlspecialchars($current['pattern']['frequency'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>" title="Controls how often the pattern repeats">
         <span id="pattern_freq_val"></span>
         <small>Controls how often the pattern repeats.</small>
       </label>
       <label>Pattern Amplitude
-        <input type="range" min="0" max="10" step="0.1" id="pattern_amp" name="pattern_amp" value="<?= htmlspecialchars($current['pattern']['amplitude'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>" title="Adjusts the height of the wave">
+        <input type="range" min="0" max="20" step="0.5" id="pattern_amp" name="pattern_amp" value="<?= htmlspecialchars($current['pattern']['amplitude'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>" title="Adjusts the height of the wave">
         <span id="pattern_amp_val"></span>
         <small>Adjusts the height of the wave.</small>
       </label>
-      <label>Pattern Polynomial (comma-separated)
-        <input type="text" id="pattern_poly" name="pattern_poly" value="<?= htmlspecialchars(isset($current['pattern']['poly']) ? implode(',', $current['pattern']['poly']) : '', ENT_QUOTES, 'UTF-8'); ?>" title="Comma-separated coefficients that bend the wave shape">
+      <label data-feature="poly">Pattern Polynomial (comma-separated)
+        <input type="text" id="pattern_poly" name="pattern_poly" value="<?= htmlspecialchars(isset($current['pattern']['poly']) ? implode(',', $current['pattern']['poly']) : '', ENT_QUOTES, 'UTF-8'); ?>" title="Comma-separated coefficients that bend the wave shape" <?= empty($currentFeatures['poly']) ? 'disabled' : ''; ?>>
         <small>Comma-separated coefficients that bend the wave shape.</small>
       </label>
-      <label>Pattern Hue
-        <input type="range" min="0" max="360" id="pattern_hue" name="pattern_hue" value="<?= htmlspecialchars($current['pattern']['hue'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>" title="Rotates the pattern's base color">
+      <label data-feature="hue">Pattern Hue
+        <input type="range" min="0" max="360" id="pattern_hue" name="pattern_hue" value="<?= htmlspecialchars($current['pattern']['hue'] ?? '0', ENT_QUOTES, 'UTF-8'); ?>" title="Rotates the pattern's base color" <?= empty($currentFeatures['hue']) ? 'disabled' : ''; ?>>
         <span id="pattern_hue_val"></span>
         <small>Rotates the pattern's base color.</small>
       </label>
-      <label>Pattern Saturation
-        <input type="range" min="0" max="100" id="pattern_sat" name="pattern_sat" value="<?= htmlspecialchars($current['pattern']['sat'] ?? '100', ENT_QUOTES, 'UTF-8'); ?>" title="Changes the intensity of the pattern's color">
+      <label data-feature="sat">Pattern Saturation
+        <input type="range" min="0" max="200" id="pattern_sat" name="pattern_sat" value="<?= htmlspecialchars($current['pattern']['sat'] ?? '100', ENT_QUOTES, 'UTF-8'); ?>" title="Changes the intensity of the pattern's color" <?= empty($currentFeatures['sat']) ? 'disabled' : ''; ?>>
         <span id="pattern_sat_val"></span>
         <small>Changes the intensity of the pattern's color.</small>
       </label>
@@ -164,6 +307,7 @@ $current = $themes[$edit] ?? null;
 <?php else: ?>
   <ul>
     <?php foreach ($themes as $name => $t): ?>
+      <?php if (!is_array($t) || empty($t['label'])) { continue; } ?>
       <li><?= htmlspecialchars($t['label'], ENT_QUOTES, 'UTF-8'); ?> - <a href="?edit=<?= urlencode($name); ?>">Edit</a></li>
     <?php endforeach; ?>
   </ul>
@@ -183,6 +327,9 @@ $current = $themes[$edit] ?? null;
     </label>
     <label>Accent Color
       <input type="color" name="accent" value="#ff71ce">
+    </label>
+    <label>Button Text Color
+      <input type="color" name="btn_text" value="#111827">
     </label>
     <label>Header Font
       <input type="text" name="font_header" value="'Share Tech Mono', monospace">

--- a/assets/admin-pattern.js
+++ b/assets/admin-pattern.js
@@ -10,11 +10,15 @@ function drawPattern(opts) {
   ctx.beginPath();
   for (let x = 0; x < width; x++) {
     const nx = x / width;
-    let y = height / 2 + opts.amplitude * Math.sin(nx * opts.frequency * Math.PI * 2);
+    const amplitude = Number.isFinite(opts.amplitude) ? opts.amplitude : 0;
+    const frequency = Number.isFinite(opts.frequency) ? opts.frequency : 0;
+    let y = height / 2 + amplitude * Math.sin(nx * frequency * Math.PI * 2);
     if (Array.isArray(opts.poly)) {
       let poly = 0;
       for (let i = 0; i < opts.poly.length; i++) {
-        poly += opts.poly[i] * Math.pow(nx, i);
+        const coeff = Number(opts.poly[i]);
+        if (!Number.isFinite(coeff)) continue;
+        poly += coeff * Math.pow(nx, i);
       }
       y += poly;
     }
@@ -33,17 +37,32 @@ function applyPattern(s) {
   if (!s || Object.keys(s).length === 0) {
     root.style.setProperty('--header-pattern', 'none');
     root.style.setProperty('--footer-pattern', 'none');
+    root.style.setProperty('--pattern-hue', '0deg');
+    root.style.setProperty('--pattern-sat', '100%');
+    root.removeAttribute('data-pattern-preset');
     return;
   }
-  const url = drawPattern({
+  const features = s.features && typeof s.features === 'object' ? s.features : {};
+  const polyValues = features.poly
+    ? (Array.isArray(s.poly) ? s.poly.map(Number).filter(n => Number.isFinite(n)) : [])
+    : [];
+  const data = {
     frequency: Number(s.frequency) || 0,
     amplitude: Number(s.amplitude) || 0,
-    poly: Array.isArray(s.poly) ? s.poly : [0]
-  });
+    poly: polyValues,
+  };
+  const url = drawPattern(data);
   root.style.setProperty('--header-pattern', `url(${url})`);
   root.style.setProperty('--footer-pattern', `url(${url})`);
-  root.style.setProperty('--pattern-hue', (s.hue || 0) + 'deg');
-  root.style.setProperty('--pattern-sat', (s.sat || 100) + '%');
+  const hue = features.hue ? Number(s.hue) || 0 : 0;
+  const sat = features.sat ? Number(s.sat) || 100 : 100;
+  root.style.setProperty('--pattern-hue', `${hue}deg`);
+  root.style.setProperty('--pattern-sat', `${sat}%`);
+  if (s.preset) {
+    root.setAttribute('data-pattern-preset', s.preset);
+  } else {
+    root.removeAttribute('data-pattern-preset');
+  }
 }
 
 window.generateVaporwavePattern = applyPattern;

--- a/assets/admin-theme.js
+++ b/assets/admin-theme.js
@@ -6,9 +6,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const gradientInput = document.getElementById('gradient');
   const ctaGradientInput = form.querySelector('[name="cta_gradient"]');
   const ctaDepthInput = form.querySelector('[name="cta_depth"]');
+  const btnTextInput = form.querySelector('[name="btn_text"]');
+
   document.querySelectorAll('.gradient-preset').forEach(btn => {
     btn.addEventListener('click', () => {
-      gradientInput.value = btn.dataset.gradient;
+      if (gradientInput) {
+        gradientInput.value = btn.dataset.gradient;
+      }
       document.querySelectorAll('.gradient-preset').forEach(b => b.classList.remove('selected'));
       btn.classList.add('selected');
       preview();
@@ -27,11 +31,125 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const patternToggle = document.getElementById('pattern_toggle');
   const patternSettings = document.getElementById('pattern_settings');
+  let patternPresets = {};
+  let featureTargets = {};
+  let featureCheckboxes = [];
+  let presetRadios = [];
+
+  if (patternSettings) {
+    try {
+      patternPresets = patternSettings.dataset.presets ? JSON.parse(patternSettings.dataset.presets) : {};
+    } catch (err) {
+      patternPresets = {};
+      console.error('Failed to parse wave presets', err);
+    }
+    featureTargets = Array.from(patternSettings.querySelectorAll('[data-feature]')).reduce((acc, wrapper) => {
+      const feature = wrapper.getAttribute('data-feature');
+      if (!feature) return acc;
+      const inputs = Array.from(wrapper.querySelectorAll('input, textarea, select'));
+      acc[feature] = { wrapper, inputs };
+      return acc;
+    }, {});
+    featureCheckboxes = Array.from(patternSettings.querySelectorAll('input[name="pattern_features[]"]'));
+    presetRadios = Array.from(patternSettings.querySelectorAll('input[name="pattern_preset"]'));
+  }
+
+  const isPatternEnabled = () => !patternToggle || patternToggle.checked;
+
+  function toggleFeature(feature, enabled) {
+    const target = featureTargets[feature];
+    if (!target) return;
+    const active = enabled && isPatternEnabled();
+    target.inputs.forEach(input => {
+      input.disabled = !active;
+    });
+    if (target.wrapper) {
+      target.wrapper.classList.toggle('feature-disabled', !active);
+    }
+  }
+
+  function syncFeatures() {
+    featureCheckboxes.forEach(cb => toggleFeature(cb.value, cb.checked));
+  }
+
+  function readSelectedFeatures() {
+    const selections = {};
+    featureCheckboxes.forEach(cb => {
+      selections[cb.value] = cb.checked && isPatternEnabled();
+    });
+    return selections;
+  }
+
+  function applyPreset(presetKey) {
+    const preset = patternPresets[presetKey];
+    if (!preset) return;
+    if (form.pattern_freq) {
+      form.pattern_freq.value = preset.frequency;
+      form.pattern_freq.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    if (form.pattern_amp) {
+      form.pattern_amp.value = preset.amplitude;
+      form.pattern_amp.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    if (form.pattern_poly) {
+      form.pattern_poly.value = Array.isArray(preset.poly) ? preset.poly.join(',') : '';
+    }
+    if (form.pattern_hue) {
+      form.pattern_hue.value = typeof preset.hue === 'number' ? preset.hue : 0;
+      form.pattern_hue.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    if (form.pattern_sat) {
+      form.pattern_sat.value = typeof preset.sat === 'number' ? preset.sat : 100;
+      form.pattern_sat.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    if (preset.features) {
+      featureCheckboxes.forEach(cb => {
+        if (Object.prototype.hasOwnProperty.call(preset.features, cb.value)) {
+          cb.checked = !!preset.features[cb.value];
+        }
+      });
+    }
+    syncFeatures();
+    preview();
+  }
+
   if (patternToggle && patternSettings) {
     patternToggle.addEventListener('change', () => {
       patternSettings.style.display = patternToggle.checked ? 'block' : 'none';
+      syncFeatures();
       preview();
     });
+  }
+
+  if (featureCheckboxes.length) {
+    featureCheckboxes.forEach(cb => {
+      toggleFeature(cb.value, cb.checked);
+      cb.addEventListener('change', () => {
+        toggleFeature(cb.value, cb.checked);
+        preview();
+      });
+    });
+  }
+
+  if (presetRadios.length) {
+    presetRadios.forEach(radio => {
+      radio.addEventListener('change', () => {
+        if (radio.checked && radio.value !== 'custom') {
+          applyPreset(radio.value);
+        } else {
+          preview();
+        }
+      });
+    });
+    const presetFromData = patternSettings ? patternSettings.dataset.currentPreset : null;
+    if (presetFromData && presetFromData !== 'custom') {
+      const activeRadio = presetRadios.find(r => r.value === presetFromData);
+      if (activeRadio && activeRadio.checked && isPatternEnabled()) {
+        applyPreset(presetFromData);
+      }
+    } else {
+      syncFeatures();
+    }
   }
 
   function preview() {
@@ -43,25 +161,37 @@ document.addEventListener('DOMContentLoaded', () => {
     if (accent) root.style.setProperty('--accent', accent.value);
     if (gradientInput) root.style.setProperty('--gradient', gradientInput.value);
     if (ctaGradientInput) root.style.setProperty('--cta-gradient', ctaGradientInput.value);
-    if (ctaDepthInput) root.style.setProperty('--cta-depth', ctaDepthInput.value + 'px');
+    if (ctaDepthInput) root.style.setProperty('--cta-depth', `${ctaDepthInput.value}px`);
+    if (btnTextInput) root.style.setProperty('--btn-text', btnTextInput.value);
     ['vap1', 'vap2', 'vap3'].forEach(v => {
       const el = form.querySelector(`[name="${v}"]`);
       if (el) root.style.setProperty(`--${v}`, el.value);
     });
-    [['font_header','--font-header'], ['font_body','--font-body'], ['font_paragraph','--font-paragraph']].forEach(([name, varName]) => {
+    [['font_header', '--font-header'], ['font_body', '--font-body'], ['font_paragraph', '--font-paragraph']].forEach(([name, varName]) => {
       const el = form.querySelector(`[name="${name}"]`);
       if (el) root.style.setProperty(varName, el.value);
     });
-    if (patternToggle && patternToggle.checked) {
-      const s = {
-        frequency: form.pattern_freq.value,
-        amplitude: form.pattern_amp.value,
-        poly: form.pattern_poly.value.split(',').map(Number).filter(n => !isNaN(n)),
-        hue: form.pattern_hue.value,
-        sat: form.pattern_sat.value,
+
+    if (isPatternEnabled()) {
+      const features = readSelectedFeatures();
+      let preset = 'custom';
+      if (patternSettings) {
+        const selectedPresetInput = patternSettings.querySelector('input[name="pattern_preset"]:checked');
+        if (selectedPresetInput && selectedPresetInput.value) {
+          preset = selectedPresetInput.value;
+        }
+      }
+      const data = {
+        preset,
+        frequency: form.pattern_freq ? form.pattern_freq.value : 0,
+        amplitude: form.pattern_amp ? form.pattern_amp.value : 0,
+        poly: features.poly && form.pattern_poly ? form.pattern_poly.value.split(',').map(Number).filter(n => !Number.isNaN(n)) : [],
+        hue: features.hue && form.pattern_hue ? form.pattern_hue.value : 0,
+        sat: features.sat && form.pattern_sat ? form.pattern_sat.value : 100,
+        features,
       };
       if (window.generateVaporwavePattern) {
-        window.generateVaporwavePattern(s);
+        window.generateVaporwavePattern(data);
       }
     } else if (window.generateVaporwavePattern) {
       window.generateVaporwavePattern(null);

--- a/assets/style.css
+++ b/assets/style.css
@@ -20,7 +20,7 @@
   --bg: var(--color-bg);
   --fg: var(--color-text);
   --accent: var(--color-accent);
-  --btn-text: #000000;
+  --btn-text: var(--fg);
   --gradient: linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%);
   --vap1: #ff71ce;
   --vap2: #01cdfe;
@@ -45,7 +45,6 @@
   --bg: #1b1135;
   --fg: #e0d9f6;
   --accent: #01cdfe;
-  --btn-text: #000000;
   --gradient: linear-gradient(135deg, #2d1e59 0%, #09002e 100%);
 }
 
@@ -53,7 +52,6 @@
   --bg: rgba(0, 0, 0, 0.3);
   --fg: #ffffff;
   --accent: var(--vap1);
-  --btn-text: #000000;
   --gradient: linear-gradient(-45deg, var(--vap1), var(--vap2), var(--vap3), var(--vap1));
 }
 
@@ -432,7 +430,7 @@ footer:focus-within {
 
 .vip-badge {
   background: gold;
-  color: #000;
+  color: var(--btn-text);
   font-size: 0.75em;
   padding: 2px 4px;
   border-radius: 3px;
@@ -477,6 +475,60 @@ footer:focus-within {
   border: 1px solid #eedc82;
   padding: 0.5rem;
   margin: 0.5rem 0;
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.alert.success {
+  border-color: rgba(34, 139, 34, 0.4);
+  background: rgba(46, 204, 113, 0.15);
+  color: #1f6a36;
+}
+
+.alert.error {
+  border-color: rgba(220, 53, 69, 0.4);
+  background: rgba(220, 53, 69, 0.1);
+  color: #7a1320;
+}
+
+.support-filter {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin: 1rem 0;
+}
+
+.support-form {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 640px;
+}
+
+.support-form textarea {
+  min-height: 160px;
+}
+
+.support-ticket-table select {
+  min-width: 140px;
+}
+
+.support-update-form {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.support-ticket-table td:last-child {
+  white-space: nowrap;
 }
 
 /* Navigation */
@@ -801,6 +853,40 @@ form button:active {
   box-shadow: inset 0 -2px 0 rgba(255, 255, 255, 0.2),
     inset 0 2px 0 rgba(0, 0, 0, 0.4),
     inset 0 calc(var(--btn-depth) / 3) 0 rgba(0, 0, 0, 0.4);
+}
+
+#pattern_settings .pattern-presets,
+#pattern_settings .pattern-features {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+#pattern_settings .pattern-preset,
+#pattern_settings .pattern-feature {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.15);
+}
+
+#pattern_settings .pattern-preset input,
+#pattern_settings .pattern-feature input {
+  accent-color: var(--accent);
+}
+
+#pattern_settings .feature-disabled {
+  opacity: 0.6;
+}
+
+#pattern_settings label[data-feature] {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
 }
 
 /* Theme modal */
@@ -1240,6 +1326,42 @@ body.nav-open .hero {
   margin-left: 4px;
 }
 
+.badge-official {
+  background: #2ecc71;
+}
+
+.badge-community {
+  background: #7f8c8d;
+}
+
+.order-direction-buy {
+  color: #2980b9;
+  font-weight: 600;
+}
+
+.order-direction-sell {
+  color: #27ae60;
+  font-weight: 600;
+}
+
+.order-direction-observer {
+  color: #7f8c8d;
+  font-weight: 600;
+}
+
+.order-detail section {
+  margin-bottom: 1.5rem;
+}
+
+.order-detail ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.order-detail ul li {
+  margin-bottom: 0.5rem;
+}
+
 .conversation-list {
   list-style: none;
   padding: 0;
@@ -1427,3 +1549,184 @@ body.nav-open .hero {
   border: 1px dashed var(--fg);
 }
 
+
+.btn-secondary {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--fg);
+  padding: 0.35rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+  cursor: pointer;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.table-listings {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.table-listings th,
+.table-listings td {
+  padding: 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  vertical-align: top;
+}
+
+.listing-tags {
+  min-width: 220px;
+}
+
+.tag-badges,
+.tag-badge-list,
+.result-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.25rem 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tag-badge-list {
+  margin-top: 0.5rem;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 999px;
+  padding: 0.1rem 0.6rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.5px;
+  text-transform: none;
+}
+
+.tag-chip-static {
+  padding-right: 0.6rem;
+}
+
+.tag-chip-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.tag-empty {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.tag-input {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  padding: 0.35rem;
+  border-radius: 6px;
+}
+
+.tag-input input[data-tag-source] {
+  flex: 1 0 120px;
+  min-width: 140px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0.25rem;
+}
+
+.tag-input input[data-tag-source]:focus {
+  outline: none;
+}
+
+.tag-list {
+  display: contents;
+}
+
+.tag-edit-form {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: none;
+  width: 100%;
+}
+
+.filter-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tag-filter {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.5rem;
+  border-radius: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag-filter legend {
+  padding: 0 0.25rem;
+  font-size: 0.75rem;
+  letter-spacing: 1px;
+}
+
+.tag-filter-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: none;
+}
+
+.tag-filter-option input[type='checkbox'] {
+  accent-color: var(--accent);
+}
+
+.listing-search-results {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.listing-search-results .result-meta {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.result-tags {
+  margin-left: 0.5rem;
+}
+
+.field-hint {
+  display: block;
+  font-size: 0.7rem;
+  margin-top: 0.25rem;
+  opacity: 0.75;
+  text-transform: none;
+}

--- a/assets/tags.js
+++ b/assets/tags.js
@@ -1,0 +1,98 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const normalizeTag = (value) => {
+    if (!value) {
+      return null;
+    }
+    let tag = value.toLowerCase().trim();
+    if (!tag) {
+      return null;
+    }
+    tag = tag.replace(/[^a-z0-9\s_-]/g, '');
+    tag = tag.replace(/\s+/g, '-');
+    tag = tag.replace(/^[\-_]+|[\-_]+$/g, '');
+    return tag || null;
+  };
+
+  const parseTags = (value) => {
+    if (!value) {
+      return [];
+    }
+    const parts = value.split(',');
+    const seen = new Set();
+    parts.forEach((part) => {
+      const normalized = normalizeTag(part);
+      if (normalized) {
+        seen.add(normalized);
+      }
+    });
+    return Array.from(seen);
+  };
+
+  document.querySelectorAll('[data-tag-editor]').forEach((editor) => {
+    const listEl = editor.querySelector('[data-tag-list]');
+    const input = editor.querySelector('[data-tag-source]');
+    const store = editor.querySelector('[data-tag-store]');
+    if (!listEl || !input || !store) {
+      return;
+    }
+
+    let tags = parseTags(store.value);
+
+    const render = () => {
+      listEl.innerHTML = '';
+      tags.forEach((tag) => {
+        const chip = document.createElement('span');
+        chip.className = 'tag-chip';
+        chip.textContent = tag;
+
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'tag-chip-remove';
+        remove.setAttribute('aria-label', `Remove tag ${tag}`);
+        remove.textContent = '×';
+        remove.addEventListener('click', () => {
+          tags = tags.filter((t) => t !== tag);
+          updateStore();
+        });
+
+        chip.appendChild(remove);
+        listEl.appendChild(chip);
+      });
+    };
+
+    const updateStore = () => {
+      store.value = tags.join(', ');
+      render();
+    };
+
+    const commitInput = () => {
+      const raw = input.value;
+      if (!raw) {
+        return;
+      }
+      const parts = raw.split(',');
+      parts.forEach((part) => {
+        const normalized = normalizeTag(part);
+        if (normalized && !tags.includes(normalized)) {
+          tags.push(normalized);
+        }
+      });
+      input.value = '';
+      updateStore();
+    };
+
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ',') {
+        event.preventDefault();
+        commitInput();
+      } else if (event.key === 'Backspace' && input.value === '') {
+        tags.pop();
+        updateStore();
+      }
+    });
+
+    input.addEventListener('blur', commitInput);
+
+    updateStore();
+  });
+});

--- a/assets/theme-toggle.js
+++ b/assets/theme-toggle.js
@@ -9,6 +9,35 @@ const errorMsg = modal ? modal.querySelector('.theme-error') : null;
 let themes = {};
 let borders = {};
 
+function normalizePattern(pattern) {
+  if (!pattern || typeof pattern !== 'object') {
+    return null;
+  }
+  const rawFeatures = pattern.features && typeof pattern.features === 'object' ? pattern.features : {};
+  const features = {
+    poly: !!rawFeatures.poly,
+    hue: !!rawFeatures.hue,
+    sat: !!rawFeatures.sat,
+  };
+  const frequency = Number(pattern.frequency);
+  const amplitude = Number(pattern.amplitude);
+  const polyValues = features.poly && Array.isArray(pattern.poly)
+    ? pattern.poly.map(Number).filter(n => Number.isFinite(n))
+    : [];
+  const hue = features.hue ? Number(pattern.hue) || 0 : 0;
+  const sat = features.sat ? Number(pattern.sat) || 100 : 100;
+  const preset = typeof pattern.preset === 'string' ? pattern.preset : 'custom';
+  return {
+    preset,
+    frequency: Number.isFinite(frequency) ? frequency : 0,
+    amplitude: Number.isFinite(amplitude) ? amplitude : 0,
+    poly: polyValues,
+    hue,
+    sat,
+    features,
+  };
+}
+
 function setActiveButton(name) {
   if (!optionsContainer) return;
   optionsContainer.querySelectorAll('button').forEach(btn => {
@@ -25,10 +54,11 @@ function applyTheme(name) {
   if (preview) preview.setAttribute('data-theme', name);
   Object.keys(t.vars || {}).forEach(k => root.style.setProperty(k, t.vars[k]));
   if (window.generateVaporwavePattern) {
-    if (t.pattern) {
-      window.generateVaporwavePattern(t.pattern);
+    const normalized = normalizePattern(t.pattern);
+    if (normalized) {
+      window.generateVaporwavePattern(normalized);
     } else {
-      window.generateVaporwavePattern({});
+      window.generateVaporwavePattern(null);
     }
   }
   localStorage.setItem('theme', name);

--- a/assets/themes.json
+++ b/assets/themes.json
@@ -5,7 +5,7 @@
       "--bg": "#2d1e59",
       "--fg": "#f8f9fa",
       "--accent": "#ff71ce",
-      "--btn-text": "#000000",
+      "--btn-text": "#1b1135",
       "--gradient": "linear-gradient(135deg, #ff71ce 0%, #01cdfe 100%)",
       "--font-header": "'Share Tech Mono', monospace",
       "--font-body": "'Share Tech Mono', monospace",
@@ -20,7 +20,7 @@
       "--bg": "#1b1135",
       "--fg": "#e0d9f6",
       "--accent": "#01cdfe",
-      "--btn-text": "#000000",
+      "--btn-text": "#041227",
       "--gradient": "linear-gradient(135deg, #2d1e59 0%, #09002e 100%)",
       "--font-header": "'Share Tech Mono', monospace",
       "--font-body": "'Share Tech Mono', monospace",
@@ -35,7 +35,7 @@
       "--bg": "rgba(0, 0, 0, 0.3)",
       "--fg": "#ffffff",
       "--accent": "var(--vap1)",
-      "--btn-text": "#000000",
+      "--btn-text": "#12002c",
       "--gradient": "linear-gradient(-45deg, var(--vap1), var(--vap2), var(--vap3), var(--vap1))",
       "--vap1": "#ff71ce",
       "--vap2": "#01cdfe",
@@ -47,11 +47,17 @@
       "--cta-depth": "20px"
     },
     "pattern": {
-      "frequency": 5,
-      "amplitude": 20,
-      "poly": [0],
-      "hue": 0,
-      "sat": 100
+      "preset": "dramatic",
+      "frequency": 6,
+      "amplitude": 16,
+      "poly": [0, 12, -10],
+      "hue": 280,
+      "sat": 130,
+      "features": {
+        "poly": true,
+        "hue": true,
+        "sat": true
+      }
     }
   },
   "pastel": {
@@ -60,7 +66,7 @@
       "--bg": "#ffe4e1",
       "--fg": "#333333",
       "--accent": "#ffb6c1",
-      "--btn-text": "#000000",
+      "--btn-text": "#2d1e59",
       "--gradient": "linear-gradient(135deg, #ffe4e1 0%, #e0ffff 100%)",
       "--font-header": "'Share Tech Mono', monospace",
       "--font-body": "'Share Tech Mono', monospace",
@@ -75,7 +81,7 @@
       "--bg": "#2e3d2f",
       "--fg": "#e6e8e6",
       "--accent": "#4caf50",
-      "--btn-text": "#000000",
+      "--btn-text": "#102512",
       "--gradient": "linear-gradient(135deg, #2e3d2f 0%, #1b2c20 100%)",
       "--font-header": "'Share Tech Mono', monospace",
       "--font-body": "'Share Tech Mono', monospace",

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -15,6 +15,7 @@
         <li><a href="/dashboard.php">Dashboard</a></li>
         <li><a href="/my-listings.php">My Listings</a></li>
         <li><a href="/messages.php">Messages</a></li>
+        <li><a href="/support.php">Support</a></li>
         <li><a href="/logout.php">Logout</a></li>
       </ul>
     </nav>
@@ -23,6 +24,7 @@
       <ul>
         <li><a href="/about.php">About Us</a></li>
         <li><a href="/help.php">Help</a></li>
+        <li><a href="/support.php">Contact Support</a></li>
         <li><a href="/vip.php">VIP Plans</a></li>
         <li><a href="/terms.php">Terms</a></li>
         <li><a href="/privacy.php">Privacy</a></li>

--- a/includes/header.php
+++ b/includes/header.php
@@ -53,6 +53,7 @@ endif;
       <a href="/index.php" data-i18n="home">Home</a>
       <a href="/about.php" data-i18n="about">About</a>
       <a href="/help.php" data-i18n="help">Help/FAQ</a>
+      <a href="/support.php" data-i18n="support">Support</a>
     </nav>
   </div>
   <div class="search-container header-center">

--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -14,6 +14,12 @@ function notification_message($type, $context = []) {
         'shipping_update' => 'Shipping details updated for trade offer #' . ($context['offer_id'] ?? ''),
     ];
 
+    if ($type === 'support_ticket') {
+        $from = $context['username'] ?? 'a user';
+        $subject = $context['subject'] ?? 'Support ticket';
+        return "New support ticket from $from: $subject";
+    }
+
     if ($type === 'service_status') {
         $map = [
             'New'              => 'Your service request was received.',

--- a/includes/orders.php
+++ b/includes/orders.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Helper functions for retrieving enriched order data.
+ */
+
+require_once __DIR__ . '/db.php';
+
+/**
+ * Fetch all orders that involve the provided viewer.
+ *
+ * @param mysqli $conn
+ * @param int    $viewerId
+ * @return array<int, array<string, mixed>>
+ */
+function fetch_orders_for_user(mysqli $conn, int $viewerId): array {
+    $sql = _orders_build_select_sql(
+        'CASE WHEN l.owner_id = ? THEN "sell" WHEN of.user_id = ? OR pay.user_id = ? THEN "buy" ELSE "observer" END'
+    );
+    $sql .= ' WHERE (of.user_id = ? OR l.owner_id = ? OR pay.user_id = ?)'
+         . ' ORDER BY of.created_at DESC';
+
+    $stmt = $conn->prepare($sql);
+    if ($stmt === false) {
+        error_log('Failed to prepare order lookup: ' . $conn->error);
+        return [];
+    }
+
+    $stmt->bind_param('iiiiii', $viewerId, $viewerId, $viewerId, $viewerId, $viewerId, $viewerId);
+    if (!$stmt->execute()) {
+        error_log('Failed to execute order lookup: ' . $stmt->error);
+        $stmt->close();
+        return [];
+    }
+
+    $result = $stmt->get_result();
+    $orders = [];
+    while ($row = $result->fetch_assoc()) {
+        $orders[] = _orders_normalize_row($row);
+    }
+    $stmt->close();
+
+    return $orders;
+}
+
+/**
+ * Fetch all orders for the admin dashboard.
+ *
+ * @param mysqli   $conn
+ * @param bool|null $officialOnly true to fetch only official inventory, false for community, null for all
+ * @param int|null $viewerId Optional viewer for direction context.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function fetch_orders_for_admin(mysqli $conn, ?bool $officialOnly = null, ?int $viewerId = null): array {
+    $viewer = $viewerId ?? 0;
+    $sql = _orders_build_select_sql(
+        'CASE WHEN l.owner_id = ? THEN "sell" WHEN of.user_id = ? OR pay.user_id = ? THEN "buy" ELSE "observer" END'
+    );
+    $sql .= ' WHERE 1=1';
+    if ($officialOnly === true) {
+        $sql .= ' AND prod.is_official = 1';
+    } elseif ($officialOnly === false) {
+        $sql .= ' AND prod.is_official = 0';
+    }
+    $sql .= ' ORDER BY of.created_at DESC';
+
+    $stmt = $conn->prepare($sql);
+    if ($stmt === false) {
+        error_log('Failed to prepare admin order lookup: ' . $conn->error);
+        return [];
+    }
+
+    $stmt->bind_param('iii', $viewer, $viewer, $viewer);
+    if (!$stmt->execute()) {
+        error_log('Failed to execute admin order lookup: ' . $stmt->error);
+        $stmt->close();
+        return [];
+    }
+
+    $result = $stmt->get_result();
+    $orders = [];
+    while ($row = $result->fetch_assoc()) {
+        $orders[] = _orders_normalize_row($row);
+    }
+    $stmt->close();
+
+    return $orders;
+}
+
+/**
+ * Fetch a single order for the current user, enforcing participation.
+ */
+function fetch_order_detail_for_user(mysqli $conn, int $orderId, int $viewerId): ?array {
+    $sql = _orders_build_select_sql(
+        'CASE WHEN l.owner_id = ? THEN "sell" WHEN of.user_id = ? OR pay.user_id = ? THEN "buy" ELSE "observer" END'
+    );
+    $sql .= ' WHERE of.id = ? AND (of.user_id = ? OR l.owner_id = ? OR pay.user_id = ?)'
+         . ' LIMIT 1';
+
+    $stmt = $conn->prepare($sql);
+    if ($stmt === false) {
+        error_log('Failed to prepare order detail lookup: ' . $conn->error);
+        return null;
+    }
+
+    $stmt->bind_param('iiiiiii', $viewerId, $viewerId, $viewerId, $orderId, $viewerId, $viewerId, $viewerId);
+    if (!$stmt->execute()) {
+        error_log('Failed to execute order detail lookup: ' . $stmt->error);
+        $stmt->close();
+        return null;
+    }
+
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    return $row ? _orders_normalize_row($row) : null;
+}
+
+/**
+ * Fetch a single order for administrative review.
+ */
+function fetch_order_detail_for_admin(mysqli $conn, int $orderId, ?int $viewerId = null): ?array {
+    $viewer = $viewerId ?? 0;
+    $sql = _orders_build_select_sql(
+        'CASE WHEN l.owner_id = ? THEN "sell" WHEN of.user_id = ? OR pay.user_id = ? THEN "buy" ELSE "observer" END'
+    );
+    $sql .= ' WHERE of.id = ? LIMIT 1';
+
+    $stmt = $conn->prepare($sql);
+    if ($stmt === false) {
+        error_log('Failed to prepare admin order detail lookup: ' . $conn->error);
+        return null;
+    }
+
+    $stmt->bind_param('iiii', $viewer, $viewer, $viewer, $orderId);
+    if (!$stmt->execute()) {
+        error_log('Failed to execute admin order detail lookup: ' . $stmt->error);
+        $stmt->close();
+        return null;
+    }
+
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    return $row ? _orders_normalize_row($row) : null;
+}
+
+/**
+ * Build the base SELECT clause for order lookups.
+ */
+function _orders_build_select_sql(string $directionExpression): string {
+    return 'SELECT'
+        . ' of.id AS id,'
+        . ' of.status AS shipping_status,'
+        . ' of.tracking_number,'
+        . ' of.delivery_method,'
+        . ' of.notes,'
+        . ' of.created_at AS placed_at,'
+        . ' of.user_id AS fulfillment_user_id,'
+        . ' pay.id AS payment_id,'
+        . ' pay.status AS payment_status,'
+        . ' pay.amount AS payment_amount,'
+        . ' pay.payment_id AS payment_reference,'
+        . ' pay.created_at AS payment_created_at,'
+        . ' pay.user_id AS payment_user_id,'
+        . ' l.id AS listing_id,'
+        . ' l.title AS listing_title,'
+        . ' l.owner_id AS listing_owner_id,'
+        . ' l.price AS listing_price,'
+        . ' l.status AS listing_status,'
+        . ' prod.sku AS product_sku,'
+        . ' prod.title AS product_title,'
+        . ' prod.quantity AS product_quantity,'
+        . ' prod.reorder_threshold AS product_reorder_threshold,'
+        . ' prod.is_official AS product_is_official,'
+        . ' seller.username AS seller_username,'
+        . ' buyer.username AS buyer_username,'
+        . ' ' . $directionExpression . ' AS direction'
+        . ' FROM order_fulfillments of'
+        . ' JOIN listings l ON of.listing_id = l.id'
+        . ' JOIN products prod ON l.product_sku = prod.sku'
+        . ' LEFT JOIN payments pay ON of.payment_id = pay.id'
+        . ' LEFT JOIN users seller ON l.owner_id = seller.id'
+        . ' LEFT JOIN users buyer ON pay.user_id = buyer.id';
+}
+
+/**
+ * Normalise database rows into a structured array.
+ */
+function _orders_normalize_row(array $row): array {
+    return [
+        'id' => (int) $row['id'],
+        'direction' => $row['direction'],
+        'shipping_status' => $row['shipping_status'] ?? 'pending',
+        'tracking_number' => $row['tracking_number'],
+        'delivery_method' => $row['delivery_method'],
+        'notes' => $row['notes'],
+        'placed_at' => $row['placed_at'],
+        'fulfillment_user_id' => (int) $row['fulfillment_user_id'],
+        'listing' => [
+            'id' => (int) $row['listing_id'],
+            'title' => $row['listing_title'],
+            'price' => $row['listing_price'],
+            'status' => $row['listing_status'],
+            'owner_id' => (int) $row['listing_owner_id'],
+            'owner_username' => $row['seller_username'],
+        ],
+        'product' => [
+            'sku' => $row['product_sku'],
+            'title' => $row['product_title'],
+            'quantity' => (int) $row['product_quantity'],
+            'reorder_threshold' => (int) $row['product_reorder_threshold'],
+            'is_official' => (bool) $row['product_is_official'],
+        ],
+        'payment' => [
+            'id' => $row['payment_id'] !== null ? (int) $row['payment_id'] : null,
+            'amount' => $row['payment_amount'] !== null ? (int) $row['payment_amount'] : null,
+            'status' => $row['payment_status'],
+            'reference' => $row['payment_reference'],
+            'created_at' => $row['payment_created_at'],
+        ],
+        'buyer' => [
+            'id' => $row['payment_user_id'] !== null ? (int) $row['payment_user_id'] : null,
+            'username' => $row['buyer_username'],
+        ],
+    ];
+}

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -20,6 +20,7 @@
       <li><a href="forum/">Forum</a></li>
       <li><a href="terms.php">Terms</a></li>
       <li><a href="privacy.php">Privacy</a></li>
+      <li><a href="support.php">Support</a></li>
     </ul>
   </div>
 </nav>

--- a/includes/support.php
+++ b/includes/support.php
@@ -1,0 +1,312 @@
+<?php
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/notifications.php';
+
+if (!function_exists('send_email')) {
+    $mailPath = __DIR__ . '/../mail.php';
+    if (file_exists($mailPath)) {
+        require_once $mailPath;
+    }
+}
+
+/**
+ * Fetch all administrators and moderators that should receive support tickets.
+ *
+ * @param mysqli $conn
+ * @return array<int, array{id:int, username:string, email:?string}>
+ */
+function get_support_admins(mysqli $conn): array {
+    $admins = [];
+    if ($stmt = $conn->prepare('SELECT id, username, email FROM users WHERE is_admin = 1 ORDER BY id ASC')) {
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $admins = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
+        $stmt->close();
+    }
+    return $admins;
+}
+
+/**
+ * Create a support ticket and fan out the initial message to all administrators.
+ *
+ * @param mysqli $conn
+ * @param int    $user_id
+ * @param string $subject
+ * @param string $message
+ * @return array{ticket_id:int, assigned_to:?int, admins:array}
+ */
+function create_support_ticket(mysqli $conn, int $user_id, string $subject, string $message): array {
+    $subject = trim($subject);
+    $message = trim($message);
+
+    if ($subject === '' || $message === '') {
+        throw new InvalidArgumentException('Subject and message are required.');
+    }
+
+    $admins = get_support_admins($conn);
+    if (empty($admins)) {
+        throw new RuntimeException('No administrators are available to receive support tickets.');
+    }
+
+    if ($stmt = $conn->prepare('SELECT username, email FROM users WHERE id = ?')) {
+        $stmt->bind_param('i', $user_id);
+        $stmt->execute();
+        $stmt->bind_result($username, $user_email);
+        $stmt->fetch();
+        $stmt->close();
+    } else {
+        $username = 'User';
+        $user_email = null;
+    }
+
+    $assigned_to = $admins[0]['id'] ?? null;
+
+    if (!($stmt = $conn->prepare('INSERT INTO support_tickets (user_id, subject, assigned_to) VALUES (?, ?, ?)')))
+    {
+        throw new RuntimeException('Failed to prepare ticket insert: ' . $conn->error);
+    }
+    $stmt->bind_param('isi', $user_id, $subject, $assigned_to);
+    if (!$stmt->execute()) {
+        $stmt->close();
+        throw new RuntimeException('Failed to create support ticket: ' . $stmt->error);
+    }
+    $ticket_id = (int) $stmt->insert_id;
+    $stmt->close();
+
+    $category = 'support';
+
+    foreach ($admins as $admin) {
+        if ($msg = $conn->prepare('INSERT INTO message_requests (sender_id, recipient_id, body, support_ticket_id, category) VALUES (?, ?, ?, ?, ?)')) {
+            $msg->bind_param('iisis', $user_id, $admin['id'], $message, $ticket_id, $category);
+            $msg->execute();
+            $msg->close();
+        }
+
+        $context = [
+            'subject'  => $subject,
+            'username' => $username,
+        ];
+        $notification = notification_message('support_ticket', $context);
+        if ($notification) {
+            create_notification($conn, (int) $admin['id'], 'support_ticket', $notification);
+        }
+
+        if (!empty($admin['email']) && function_exists('send_email')) {
+            $emailSubject = 'New support ticket: ' . $subject;
+            $emailBody = "A new support ticket was submitted by $username.\n\nSubject: $subject\n\nMessage:\n$message\n\nView the ticket in the admin panel.";
+            try {
+                send_email($admin['email'], $emailSubject, $emailBody);
+            } catch (Exception $e) {
+                error_log('Support ticket email failed: ' . $e->getMessage());
+            }
+        }
+    }
+
+    return [
+        'ticket_id'   => $ticket_id,
+        'assigned_to' => $assigned_to,
+        'admins'      => $admins,
+    ];
+}
+
+/**
+ * Retrieve support tickets for a specific user.
+ *
+ * @param mysqli $conn
+ * @param int    $user_id
+ * @return array<int, array<string, mixed>>
+ */
+function get_support_tickets_for_user(mysqli $conn, int $user_id): array {
+    $tickets = [];
+    $sql = 'SELECT t.id, t.subject, t.status, t.created_at, t.updated_at, t.assigned_to, '
+         . 'assigned.username AS assigned_username '
+         . 'FROM support_tickets t '
+         . 'LEFT JOIN users assigned ON assigned.id = t.assigned_to '
+         . 'WHERE t.user_id = ? '
+         . 'ORDER BY t.updated_at DESC';
+    if ($stmt = $conn->prepare($sql)) {
+        $stmt->bind_param('i', $user_id);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $tickets = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
+        $stmt->close();
+    }
+
+    if (empty($tickets)) {
+        return [];
+    }
+
+    $linkStmt = $conn->prepare('SELECT recipient_id FROM message_requests '
+        . 'WHERE support_ticket_id = ? AND recipient_id <> ? '
+        . 'ORDER BY created_at ASC LIMIT 1');
+    $timeStmt = $conn->prepare('SELECT MAX(created_at) FROM message_requests WHERE support_ticket_id = ?');
+    foreach ($tickets as &$ticket) {
+        $ticket['contact_id'] = null;
+        $ticket['contact_username'] = null;
+        $ticket['last_message_at'] = null;
+
+        if ($linkStmt) {
+            $linkStmt->bind_param('ii', $ticket['id'], $user_id);
+            $linkStmt->execute();
+            $linkStmt->bind_result($contact_id);
+            if ($linkStmt->fetch()) {
+                $ticket['contact_id'] = (int) $contact_id;
+            }
+            $linkStmt->free_result();
+        }
+
+        if (!empty($ticket['contact_id'])) {
+            if ($userStmt = $conn->prepare('SELECT username FROM users WHERE id = ?')) {
+                $userStmt->bind_param('i', $ticket['contact_id']);
+                $userStmt->execute();
+                $userStmt->bind_result($contact_username);
+                if ($userStmt->fetch()) {
+                    $ticket['contact_username'] = $contact_username;
+                }
+                $userStmt->close();
+            }
+        }
+
+        if ($timeStmt) {
+            $timeStmt->bind_param('i', $ticket['id']);
+            $timeStmt->execute();
+            $timeStmt->bind_result($last_message_at);
+            if ($timeStmt->fetch()) {
+                $ticket['last_message_at'] = $last_message_at;
+            }
+            $timeStmt->free_result();
+        }
+    }
+    if ($linkStmt) {
+        $linkStmt->close();
+    }
+    if ($timeStmt) {
+        $timeStmt->close();
+    }
+    return $tickets;
+}
+
+/**
+ * Retrieve support tickets for administrative review.
+ *
+ * @param mysqli     $conn
+ * @param string|null $status
+ * @return array<int, array<string, mixed>>
+ */
+function get_support_tickets(mysqli $conn, ?string $status = null): array {
+    $tickets = [];
+    $sql = 'SELECT t.id, t.user_id, t.subject, t.status, t.assigned_to, t.created_at, t.updated_at, '
+         . 'requester.username AS user_username, assigned.username AS assigned_username '
+         . 'FROM support_tickets t '
+         . 'JOIN users requester ON requester.id = t.user_id '
+         . 'LEFT JOIN users assigned ON assigned.id = t.assigned_to';
+    if ($status) {
+        $sql .= ' WHERE t.status = ?';
+    }
+    $sql .= ' ORDER BY t.updated_at DESC';
+
+    if ($stmt = $conn->prepare($sql)) {
+        if ($status) {
+            $stmt->bind_param('s', $status);
+        }
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $tickets = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
+        $stmt->close();
+    }
+
+    if (empty($tickets)) {
+        return [];
+    }
+
+    $activityStmt = $conn->prepare('SELECT MAX(created_at) AS last_message_at, '
+        . 'MAX(CASE WHEN sender_id = ? AND read_at IS NULL THEN 1 ELSE 0 END) AS unread_flag '
+        . 'FROM message_requests WHERE support_ticket_id = ?');
+
+    foreach ($tickets as &$ticket) {
+        $ticket['last_message_at'] = null;
+        $ticket['unread_flag'] = 0;
+        if ($activityStmt) {
+            $activityStmt->bind_param('ii', $ticket['user_id'], $ticket['id']);
+            $activityStmt->execute();
+            $activityStmt->bind_result($last_message_at, $unread_flag);
+            if ($activityStmt->fetch()) {
+                $ticket['last_message_at'] = $last_message_at;
+                $ticket['unread_flag'] = (int) $unread_flag;
+            }
+            $activityStmt->free_result();
+        }
+    }
+
+    if ($activityStmt) {
+        $activityStmt->close();
+    }
+
+    return $tickets;
+}
+
+/**
+ * Update the status or assignment of a support ticket.
+ *
+ * @param mysqli $conn
+ * @param int    $ticket_id
+ * @param string $status
+ * @param int|null $assigned_to
+ * @return bool
+ */
+function update_support_ticket(mysqli $conn, int $ticket_id, string $status, ?int $assigned_to): bool {
+    $allowed = ['open', 'pending', 'closed'];
+    if (!in_array($status, $allowed, true)) {
+        throw new InvalidArgumentException('Invalid ticket status.');
+    }
+
+    if ($assigned_to !== null) {
+        $stmt = $conn->prepare('SELECT 1 FROM users WHERE id = ? AND is_admin = 1');
+        if ($stmt) {
+            $stmt->bind_param('i', $assigned_to);
+            $stmt->execute();
+            $stmt->store_result();
+            if ($stmt->num_rows === 0) {
+                $stmt->close();
+                throw new InvalidArgumentException('Assigned user must be an administrator.');
+            }
+            $stmt->close();
+        }
+    }
+
+    if ($stmt = $conn->prepare('UPDATE support_tickets SET status = ?, assigned_to = ?, updated_at = NOW() WHERE id = ?')) {
+        $stmt->bind_param('sii', $status, $assigned_to, $ticket_id);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+    return false;
+}
+
+/**
+ * Touch a support ticket when a new message arrives.
+ *
+ * @param mysqli   $conn
+ * @param int      $ticket_id
+ * @param string|null $status
+ * @return void
+ */
+function touch_support_ticket(mysqli $conn, int $ticket_id, ?string $status = null): void {
+    if ($status && !in_array($status, ['open', 'pending', 'closed'], true)) {
+        $status = null;
+    }
+
+    if ($status) {
+        if ($stmt = $conn->prepare('UPDATE support_tickets SET status = ?, updated_at = NOW() WHERE id = ?')) {
+            $stmt->bind_param('si', $status, $ticket_id);
+            $stmt->execute();
+            $stmt->close();
+        }
+    } else {
+        if ($stmt = $conn->prepare('UPDATE support_tickets SET updated_at = NOW() WHERE id = ?')) {
+            $stmt->bind_param('i', $ticket_id);
+            $stmt->execute();
+            $stmt->close();
+        }
+    }
+}

--- a/includes/tags.php
+++ b/includes/tags.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Normalize a single tag string to a safe, comparable value.
+ */
+function normalize_tag(string $tag): ?string
+{
+    $tag = strtolower(trim($tag));
+    if ($tag === '') {
+        return null;
+    }
+
+    // Collapse internal whitespace to single hyphen for consistent storage.
+    $tag = preg_replace('/[^a-z0-9\s\-_]/', '', $tag);
+    $tag = preg_replace('/\s+/', '-', $tag);
+    $tag = trim($tag, '-_');
+
+    if ($tag === '') {
+        return null;
+    }
+
+    return $tag;
+}
+
+/**
+ * Parse a comma or newline separated list of tags provided by a user.
+ */
+function tags_from_input(?string $input): array
+{
+    if ($input === null) {
+        return [];
+    }
+
+    $parts = preg_split('/[,\n]/', $input) ?: [];
+    $normalized = [];
+    foreach ($parts as $part) {
+        $tag = normalize_tag($part);
+        if ($tag !== null) {
+            $normalized[$tag] = true;
+        }
+    }
+
+    return array_keys($normalized);
+}
+
+/**
+ * Convert normalized tags into the persisted comma-delimited format with sentinels.
+ */
+function tags_to_storage(array $tags): ?string
+{
+    if (empty($tags)) {
+        return null;
+    }
+
+    return ',' . implode(',', $tags) . ',';
+}
+
+/**
+ * Decode a stored tags string back into an array of tag values.
+ */
+function tags_from_storage(?string $stored): array
+{
+    if ($stored === null || $stored === '') {
+        return [];
+    }
+
+    $trimmed = trim($stored, ',');
+    if ($trimmed === '') {
+        return [];
+    }
+
+    $parts = explode(',', $trimmed);
+    $seen = [];
+    foreach ($parts as $part) {
+        $tag = normalize_tag($part);
+        if ($tag !== null) {
+            $seen[$tag] = true;
+        }
+    }
+
+    return array_keys($seen);
+}
+
+/**
+ * Produce a comma-separated string suitable for re-populating an input control.
+ */
+function tags_to_input_value(array $tags): string
+{
+    if (empty($tags)) {
+        return '';
+    }
+
+    return implode(', ', $tags);
+}
+
+/**
+ * Prepare parameters for SQL LIKE lookups when matching stored tags.
+ */
+function tag_like_parameter(string $tag): string
+{
+    return '%,' . $tag . ',%';
+}

--- a/listing.php
+++ b/listing.php
@@ -2,6 +2,7 @@
 session_start();
 require 'includes/db.php';
 require 'includes/csrf.php';
+require 'includes/tags.php';
 
 $listing_id = isset($_GET['listing_id']) ? intval($_GET['listing_id']) : 0;
 if (!$listing_id) {
@@ -9,7 +10,7 @@ if (!$listing_id) {
     exit;
 }
 
-$stmt = $conn->prepare('SELECT l.id, l.product_sku, p.title, p.description, p.price AS original_price, l.sale_price, l.category, l.image, l.pickup_only FROM listings l JOIN products p ON l.product_sku = p.sku WHERE l.id = ? LIMIT 1');
+$stmt = $conn->prepare('SELECT l.id, l.product_sku, p.title, p.description, p.price AS original_price, l.sale_price, l.category, l.tags, l.image, l.pickup_only FROM listings l JOIN products p ON l.product_sku = p.sku WHERE l.id = ? LIMIT 1');
 $stmt->bind_param('i', $listing_id);
 $stmt->execute();
 $result = $stmt->get_result();
@@ -41,6 +42,14 @@ if (!$listing) {
       <p class="description">
         <?= nl2br(htmlspecialchars($listing['description'])); ?>
       </p>
+      <?php $detailTags = tags_from_storage($listing['tags']); ?>
+      <?php if ($detailTags): ?>
+        <ul class="tag-badge-list">
+          <?php foreach ($detailTags as $tag): ?>
+            <li class="tag-chip tag-chip-static">#<?= htmlspecialchars($tag); ?></li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
       <?php if ($listing['sale_price'] !== null): ?>
         <p class="price"><span class="original">$<?= htmlspecialchars($listing['original_price']); ?></span> <span class="sale">$<?= htmlspecialchars($listing['sale_price']); ?></span></p>
       <?php else: ?>

--- a/migrations/028_add_is_official_to_products.sql
+++ b/migrations/028_add_is_official_to_products.sql
@@ -1,0 +1,2 @@
+ALTER TABLE products
+    ADD COLUMN is_official TINYINT(1) NOT NULL DEFAULT 0;

--- a/migrations/029_add_tags_to_listings.sql
+++ b/migrations/029_add_tags_to_listings.sql
@@ -1,0 +1,4 @@
+ALTER TABLE listings
+  ADD tags TEXT NULL AFTER category;
+
+CREATE INDEX idx_listings_tags ON listings (tags(191));

--- a/migrations/030_create_support_tickets.sql
+++ b/migrations/030_create_support_tickets.sql
@@ -1,0 +1,20 @@
+CREATE TABLE support_tickets (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  subject VARCHAR(255) NOT NULL,
+  status ENUM('open','pending','closed') DEFAULT 'open',
+  assigned_to INT DEFAULT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (assigned_to) REFERENCES users(id) ON DELETE SET NULL
+);
+
+ALTER TABLE message_requests
+  ADD COLUMN support_ticket_id INT DEFAULT NULL AFTER body,
+  ADD COLUMN category VARCHAR(32) DEFAULT NULL AFTER support_ticket_id,
+  ADD INDEX idx_message_requests_support_ticket (support_ticket_id),
+  ADD INDEX idx_message_requests_category (category),
+  ADD CONSTRAINT fk_message_requests_support_ticket
+    FOREIGN KEY (support_ticket_id) REFERENCES support_tickets(id)
+    ON DELETE SET NULL;

--- a/my-listings.php
+++ b/my-listings.php
@@ -1,8 +1,41 @@
 <?php
 require 'includes/auth.php';
 require 'includes/db.php';
+require 'includes/csrf.php';
+require 'includes/tags.php';
 
 $user_id = $_SESSION['user_id'];
+
+$message = '';
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!validate_token($_POST['csrf_token'] ?? '')) {
+    $error = 'Invalid request token.';
+  } else {
+    $listing_id = (int)($_POST['listing_id'] ?? 0);
+    $tags_input = trim($_POST['tags'] ?? '');
+    $tags = tags_from_input($tags_input);
+    $tags_storage = tags_to_storage($tags);
+    if ($listing_id > 0) {
+      if ($stmt = $conn->prepare("UPDATE listings SET tags=? WHERE id=? AND owner_id=?")) {
+        $stmt->bind_param('sii', $tags_storage, $listing_id, $user_id);
+        if ($stmt->execute()) {
+          if ($stmt->affected_rows > 0) {
+            $message = 'Tags updated.';
+          } else {
+            $message = 'No changes were made.';
+          }
+        } else {
+          $error = 'Failed to update tags.';
+        }
+        $stmt->close();
+      } else {
+        $error = 'Failed to prepare tag update.';
+      }
+    }
+  }
+}
 
 // Handle deletion
 if (isset($_GET['delete'])) {
@@ -17,7 +50,7 @@ if (isset($_GET['delete'])) {
   exit;
 }
 
-$stmt = $conn->prepare("SELECT id, title, price, category, image, status, pickup_only, created_at FROM listings WHERE owner_id = ? ORDER BY created_at DESC");
+$stmt = $conn->prepare("SELECT id, title, price, category, tags, image, status, pickup_only, created_at FROM listings WHERE owner_id = ? ORDER BY created_at DESC");
 $stmt->bind_param('i', $user_id);
 $stmt->execute();
 $listings = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
@@ -26,19 +59,48 @@ $stmt->close();
 <?php require 'includes/layout.php'; ?>
   <title>My Listings</title>
   <link rel="stylesheet" href="assets/style.css">
+  <script src="assets/tags.js" defer></script>
 </head>
 <body>
   <?php include 'includes/sidebar.php'; ?>
   <?php include 'includes/header.php'; ?>
   <h2>My Listings</h2>
+  <?php if ($message): ?>
+    <p class="notice"><?= htmlspecialchars($message); ?></p>
+  <?php endif; ?>
+  <?php if ($error): ?>
+    <p class="error"><?= htmlspecialchars($error); ?></p>
+  <?php endif; ?>
   <p><a href="sell.php">Create a new listing</a></p>
-  <table>
-    <tr><th>Title</th><th>Price</th><th>Category</th><th>Image</th><th>Status</th><th>Pickup Only</th><th>Actions</th></tr>
+  <table class="table-listings">
+    <tr><th>Title</th><th>Price</th><th>Category</th><th>Tags</th><th>Image</th><th>Status</th><th>Pickup Only</th><th>Actions</th></tr>
     <?php foreach ($listings as $l): ?>
+      <?php $tagValues = tags_from_storage($l['tags']); ?>
       <tr>
         <td><?= htmlspecialchars($l['title']) ?></td>
         <td><?= htmlspecialchars($l['price']) ?></td>
         <td><?= htmlspecialchars($l['category']) ?></td>
+        <td class="listing-tags">
+          <div class="tag-badges">
+            <?php if ($tagValues): ?>
+              <?php foreach ($tagValues as $tag): ?>
+                <span class="tag-chip tag-chip-static"><?= htmlspecialchars($tag) ?></span>
+              <?php endforeach; ?>
+            <?php else: ?>
+              <span class="tag-empty">No tags</span>
+            <?php endif; ?>
+          </div>
+          <form method="post" class="tag-edit-form">
+            <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+            <input type="hidden" name="listing_id" value="<?= $l['id']; ?>">
+            <div class="tag-input" data-tag-editor>
+              <div class="tag-list" data-tag-list></div>
+              <input type="text" data-tag-source placeholder="Add tag">
+              <input type="hidden" name="tags" value="<?= htmlspecialchars(tags_to_input_value($tagValues)); ?>" data-tag-store>
+            </div>
+            <button type="submit" class="btn-secondary">Save Tags</button>
+          </form>
+        </td>
         <td><?php if ($l['image']): ?><img class="thumb-square" style="--thumb-size:60px;" src="uploads/<?= htmlspecialchars($l['image']) ?>" alt=""><?php endif; ?></td>
         <td><?= htmlspecialchars($l['status']) ?></td>
         <td><?= $l['pickup_only'] ? 'Yes' : 'No' ?></td>

--- a/order.php
+++ b/order.php
@@ -1,0 +1,102 @@
+<?php
+require 'includes/auth.php';
+require 'includes/orders.php';
+
+$orderId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($orderId <= 0) {
+    http_response_code(404);
+    $order = null;
+} else {
+    $order = fetch_order_detail_for_user($conn, $orderId, (int) $_SESSION['user_id']);
+    if (!$order) {
+        http_response_code(404);
+    }
+}
+
+$amountDisplay = '—';
+$paymentStatus = 'pending';
+$shippingStatus = 'pending';
+$badgeClass = 'badge-community';
+$badgeLabel = 'Community Listing';
+$counterparty = null;
+if ($order) {
+    $amount = $order['payment']['amount'] ?? null;
+    if ($amount !== null) {
+        $amountDisplay = '$' . number_format(((int) $amount) / 100, 2);
+    }
+    $paymentStatus = $order['payment']['status'] ?? 'pending';
+    $shippingStatus = $order['shipping_status'] ?? 'pending';
+    $isOfficial = $order['product']['is_official'] ?? false;
+    $badgeClass = $isOfficial ? 'badge-official' : 'badge-community';
+    $badgeLabel = $isOfficial ? 'Official SkuzE' : 'Community Listing';
+    $counterparty = $order['direction'] === 'buy'
+        ? ($order['listing']['owner_username'] ?? 'Seller')
+        : ($order['buyer']['username'] ?? 'Buyer');
+}
+?>
+<?php require 'includes/layout.php'; ?>
+  <title>Order <?= $order ? '#' . htmlspecialchars((string) $order['id'], ENT_QUOTES, 'UTF-8') : '' ?></title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <div class="page-container order-detail">
+    <h2>Order Details</h2>
+    <?php if (!$order): ?>
+      <p class="notice">We couldn’t find that order or you do not have permission to view it.</p>
+      <p><a class="btn" href="dashboard.php">Return to dashboard</a></p>
+    <?php else: ?>
+      <p><a class="btn" href="dashboard.php">← Back to dashboard</a></p>
+      <section class="order-summary">
+        <h3>Summary</h3>
+        <ul>
+          <li><strong>Order ID:</strong> #<?= (int) $order['id'] ?></li>
+          <li><strong>Placed:</strong> <?= htmlspecialchars($order['placed_at'], ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Direction:</strong> <?= htmlspecialchars(ucfirst($order['direction']), ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Counterparty:</strong> <?= htmlspecialchars($counterparty ?? '—', ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Listing:</strong> <a href="listing.php?id=<?= (int) $order['listing']['id'] ?>"><?= htmlspecialchars($order['listing']['title'], ENT_QUOTES, 'UTF-8') ?></a></li>
+          <li><strong>Status:</strong> <?= htmlspecialchars(ucfirst($shippingStatus), ENT_QUOTES, 'UTF-8') ?></li>
+        </ul>
+      </section>
+      <section class="order-product">
+        <h3>Product</h3>
+        <p><span class="badge <?= htmlspecialchars($badgeClass, ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($badgeLabel, ENT_QUOTES, 'UTF-8') ?></span></p>
+        <ul>
+          <li><strong>Title:</strong> <?= htmlspecialchars($order['product']['title'] ?: $order['listing']['title'], ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>SKU:</strong> <?= htmlspecialchars($order['product']['sku'], ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Inventory remaining:</strong> <?= (int) $order['product']['quantity'] ?></li>
+          <li><strong>Reorder threshold:</strong> <?= (int) $order['product']['reorder_threshold'] ?></li>
+        </ul>
+      </section>
+      <section class="order-payment">
+        <h3>Payment</h3>
+        <ul>
+          <li><strong>Amount:</strong> <?= htmlspecialchars($amountDisplay, ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Status:</strong> <?= htmlspecialchars(ucfirst($paymentStatus ?? 'pending'), ENT_QUOTES, 'UTF-8') ?></li>
+          <?php if (!empty($order['payment']['reference'])): ?>
+          <li><strong>Reference:</strong> <?= htmlspecialchars($order['payment']['reference'], ENT_QUOTES, 'UTF-8') ?></li>
+          <?php endif; ?>
+          <?php if (!empty($order['payment']['created_at'])): ?>
+          <li><strong>Captured:</strong> <?= htmlspecialchars($order['payment']['created_at'], ENT_QUOTES, 'UTF-8') ?></li>
+          <?php endif; ?>
+        </ul>
+      </section>
+      <section class="order-shipping">
+        <h3>Fulfillment</h3>
+        <ul>
+          <li><strong>Delivery method:</strong> <?= htmlspecialchars($order['delivery_method'] ?? '—', ENT_QUOTES, 'UTF-8') ?></li>
+          <li><strong>Shipping status:</strong> <?= htmlspecialchars(ucfirst($shippingStatus), ENT_QUOTES, 'UTF-8') ?></li>
+          <?php if (!empty($order['tracking_number'])): ?>
+          <li><strong>Tracking number:</strong> <?= htmlspecialchars($order['tracking_number'], ENT_QUOTES, 'UTF-8') ?></li>
+          <?php endif; ?>
+          <?php if (!empty($order['notes'])): ?>
+          <li><strong>Notes:</strong> <?= nl2br(htmlspecialchars($order['notes'], ENT_QUOTES, 'UTF-8')) ?></li>
+          <?php endif; ?>
+        </ul>
+      </section>
+    <?php endif; ?>
+  </div>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>

--- a/schema/message_requests.sql
+++ b/schema/message_requests.sql
@@ -3,8 +3,13 @@ CREATE TABLE message_requests (
   sender_id INT NOT NULL,
   recipient_id INT NOT NULL,
   body TEXT NOT NULL,
+  support_ticket_id INT DEFAULT NULL,
+  category VARCHAR(32) DEFAULT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   read_at DATETIME DEFAULT NULL,
   FOREIGN KEY (sender_id) REFERENCES users(id) ON DELETE CASCADE,
-  FOREIGN KEY (recipient_id) REFERENCES users(id) ON DELETE CASCADE
+  FOREIGN KEY (recipient_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (support_ticket_id) REFERENCES support_tickets(id) ON DELETE SET NULL,
+  INDEX idx_message_requests_support_ticket (support_ticket_id),
+  INDEX idx_message_requests_category (category)
 );

--- a/schema/products.sql
+++ b/schema/products.sql
@@ -5,6 +5,7 @@ CREATE TABLE products (
     description TEXT,
     quantity INT NOT NULL DEFAULT 0,
     reorder_threshold INT NOT NULL DEFAULT 0,
+    is_official TINYINT(1) NOT NULL DEFAULT 0,
     owner_id INT NOT NULL,
     price DECIMAL(10,2) NOT NULL DEFAULT 0.00,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/schema/support_tickets.sql
+++ b/schema/support_tickets.sql
@@ -1,0 +1,11 @@
+CREATE TABLE support_tickets (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  subject VARCHAR(255) NOT NULL,
+  status ENUM('open','pending','closed') DEFAULT 'open',
+  assigned_to INT DEFAULT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (assigned_to) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/support.php
+++ b/support.php
@@ -1,0 +1,107 @@
+<?php
+require 'includes/auth.php';
+require 'includes/csrf.php';
+require 'includes/support.php';
+
+$user_id = (int) $_SESSION['user_id'];
+$error = '';
+$success = false;
+$ticketResult = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_token($_POST['csrf_token'] ?? '')) {
+        $error = 'Invalid CSRF token.';
+    } else {
+        $subject = trim($_POST['subject'] ?? '');
+        $message = trim($_POST['message'] ?? '');
+        try {
+            $ticketResult = create_support_ticket($conn, $user_id, $subject, $message);
+            $success = true;
+        } catch (InvalidArgumentException $e) {
+            $error = $e->getMessage();
+        } catch (RuntimeException $e) {
+            error_log('Support ticket creation failed: ' . $e->getMessage());
+            $error = 'We were unable to submit your request. Please try again later.';
+        }
+    }
+}
+
+$tickets = get_support_tickets_for_user($conn, $user_id);
+$formSubject = $success ? '' : ($_POST['subject'] ?? '');
+$formMessage = $success ? '' : ($_POST['message'] ?? '');
+?>
+<?php require 'includes/layout.php'; ?>
+  <title>Contact Support</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <?php include 'includes/sidebar.php'; ?>
+  <?php include 'includes/header.php'; ?>
+  <div class="page-container">
+    <h2>Contact Support</h2>
+    <p>If you need help from the SkuzE team, send us a message and a moderator will get back to you through Messages.</p>
+    <?php if ($success): ?>
+      <div class="alert success">
+        <p>Your support ticket has been submitted successfully.</p>
+        <?php if (!empty($ticketResult['assigned_to'])): ?>
+          <p>We'll reach out from the admin team shortly. Check your <a href="messages.php">messages</a> for updates.</p>
+        <?php endif; ?>
+      </div>
+    <?php elseif ($error): ?>
+      <div class="alert error" role="alert"><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div>
+    <?php endif; ?>
+    <form method="post" class="support-form">
+      <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+      <label for="support-subject">Subject</label>
+      <input type="text" id="support-subject" name="subject" maxlength="255" required value="<?= htmlspecialchars($formSubject, ENT_QUOTES, 'UTF-8'); ?>">
+      <label for="support-message">Message</label>
+      <textarea id="support-message" name="message" rows="6" required><?= htmlspecialchars($formMessage, ENT_QUOTES, 'UTF-8'); ?></textarea>
+      <button type="submit" class="btn">Submit Ticket</button>
+    </form>
+
+    <h3>Your Support Tickets</h3>
+    <?php if (empty($tickets)): ?>
+      <p>You have not submitted any support tickets yet.</p>
+    <?php else: ?>
+      <table class="support-ticket-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Subject</th>
+            <th>Status</th>
+            <th>Assigned</th>
+            <th>Last Update</th>
+            <th>Conversation</th>
+          </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($tickets as $ticket): ?>
+          <?php
+            $status = htmlspecialchars(ucfirst($ticket['status']), ENT_QUOTES, 'UTF-8');
+            $assignedName = $ticket['assigned_username'] ?: ($ticket['contact_username'] ?? null);
+            $assigned = $assignedName ? htmlspecialchars($assignedName, ENT_QUOTES, 'UTF-8') : 'Unassigned';
+            $lastUpdate = $ticket['last_message_at'] ? htmlspecialchars($ticket['last_message_at'], ENT_QUOTES, 'UTF-8') : htmlspecialchars($ticket['updated_at'], ENT_QUOTES, 'UTF-8');
+            $contactId = $ticket['assigned_to'] ?: ($ticket['contact_id'] ?? null);
+          ?>
+          <tr>
+            <td>#<?= (int) $ticket['id']; ?></td>
+            <td><?= htmlspecialchars($ticket['subject'], ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?= $status; ?></td>
+            <td><?= $assigned; ?></td>
+            <td><?= $lastUpdate; ?></td>
+            <td>
+              <?php if (!empty($contactId)): ?>
+                <a class="btn" href="message-thread.php?user=<?= (int) $contactId; ?>">View Messages</a>
+              <?php else: ?>
+                <span>Pending</span>
+              <?php endif; ?>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+        </tbody>
+      </table>
+    <?php endif; ?>
+  </div>
+  <?php include 'includes/footer.php'; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add migrations and a reusable support helper so tickets persist metadata, notify admins, and reuse existing messaging tables
- expose a logged-in support page and global navigation links for creating tickets and reviewing their status
- provide an admin ticket dashboard and message-thread integration to triage, assign, and respond to support requests

## Testing
- php -l support.php
- php -l includes/support.php
- php -l includes/notifications.php
- php -l message-thread.php
- php -l admin/support.php
- php -l admin/index.php
- php -l includes/header.php
- php -l includes/sidebar.php
- php -l includes/footer.php
- php -l dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb54046bc832bb96b7ef88349acac