### PR TITLE
feat(ui): 3D neon/glass CTA buttons with bloom + animated SKUZE logo (progressive, accessible)

### DIFF
--- a/assets/3d-buttons.js
+++ b/assets/3d-buttons.js
@@ -1,0 +1,510 @@
+'use strict';
+
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.module.js';
+import { EffectComposer } from 'https://cdn.jsdelivr.net/npm/three@0.161.0/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'https://cdn.jsdelivr.net/npm/three@0.161.0/examples/jsm/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'https://cdn.jsdelivr.net/npm/three@0.161.0/examples/jsm/postprocessing/UnrealBloomPass.js';
+import { RoomEnvironment } from 'https://cdn.jsdelivr.net/npm/three@0.161.0/examples/jsm/environments/RoomEnvironment.js';
+
+const supportsWebGL = (() => {
+  try {
+    const canvas = document.createElement('canvas');
+    return (
+      (!!window.WebGL2RenderingContext && !!canvas.getContext('webgl2')) ||
+      !!canvas.getContext('webgl') ||
+      !!canvas.getContext('experimental-webgl')
+    );
+  } catch (error) {
+    return false;
+  }
+})();
+
+const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+const managed = new WeakSet();
+
+const buttons = Array.from(document.querySelectorAll('.cta3d'));
+if (!buttons.length) {
+  return;
+}
+
+buttons.forEach((element) => {
+  if (managed.has(element)) {
+    return;
+  }
+  managed.add(element);
+  initializeButton(element).catch((error) => {
+    console.error('Failed to initialise CTA button', error);
+  });
+});
+
+function initializeButton(element) {
+  let label = (element.dataset.label || '').trim();
+  if (!label) {
+    label = (element.textContent || '').trim() || 'Action';
+    element.dataset.label = label;
+  }
+
+  const urlAttr = (element.dataset.url || '').trim();
+  const nestedAnchor = element.querySelector('a[href]');
+  const destination = urlAttr || (nestedAnchor ? nestedAnchor.getAttribute('href') || '' : '');
+
+  element.setAttribute('role', 'button');
+  element.setAttribute('tabindex', '0');
+  element.setAttribute('aria-label', label);
+
+  const labelNode = document.createElement('span');
+  labelNode.className = 'cta3d__label';
+  labelNode.textContent = label;
+  labelNode.setAttribute('aria-hidden', 'true');
+  element.appendChild(labelNode);
+
+  const navigate = () => {
+    if (destination) {
+      window.location.href = destination;
+      return;
+    }
+    const fallbackAnchor = element.querySelector('a[href]');
+    if (fallbackAnchor) {
+      fallbackAnchor.click();
+    }
+  };
+
+  const controller = new AbortController();
+  const { signal } = controller;
+
+  element.addEventListener(
+    'click',
+    (event) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+      const target = event.target;
+      if (target instanceof Element && target.closest('a[href]')) {
+        return;
+      }
+      event.preventDefault();
+      navigate();
+    },
+    { signal }
+  );
+
+  element.addEventListener(
+    'keydown',
+    (event) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        navigate();
+      }
+    },
+    { signal }
+  );
+
+  element.addEventListener(
+    'pointerdown',
+    () => {
+      element.classList.add('cta3d--active');
+    },
+    { signal }
+  );
+
+  const clearActive = () => {
+    element.classList.remove('cta3d--active');
+  };
+
+  element.addEventListener('pointerup', clearActive, { signal });
+  element.addEventListener('pointercancel', clearActive, { signal });
+  element.addEventListener('lostpointercapture', clearActive, { signal });
+
+  const fallbackStatic = () => {
+    element.setAttribute('aria-disabled', 'true');
+    element.classList.add('cta3d--fallback');
+    labelNode.style.display = 'none';
+    if (destination && !element.querySelector('.cta3d-fallback-link')) {
+      const fallbackLink = document.createElement('a');
+      fallbackLink.className = 'cta3d-fallback-link';
+      fallbackLink.href = destination;
+      fallbackLink.textContent = label;
+      fallbackLink.setAttribute('aria-hidden', 'true');
+      element.appendChild(fallbackLink);
+    }
+  };
+
+  if (!supportsWebGL) {
+    fallbackStatic();
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      resolve(setupThreeScene(element, controller, fallbackStatic));
+    });
+  });
+}
+
+function setupThreeScene(element, controller, fallbackStatic) {
+  const { signal } = controller;
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setClearColor(0x000000, 0);
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.08;
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(40, 1, 0.1, 50);
+  camera.position.set(0, 0.25, 5);
+
+  const group = new THREE.Group();
+  group.position.y = -0.1;
+  scene.add(group);
+
+  const resources = [];
+
+  let envTarget;
+  let pmremGenerator;
+  try {
+    pmremGenerator = new THREE.PMREMGenerator(renderer);
+    pmremGenerator.compileEquirectangularShader();
+    const roomEnvironment = new RoomEnvironment();
+    envTarget = pmremGenerator.fromScene(roomEnvironment, 0.04);
+    scene.environment = envTarget.texture;
+    resources.push({ dispose: () => roomEnvironment.dispose() });
+  } catch (error) {
+    console.warn('Falling back to static CTA due to environment error', error);
+    renderer.dispose();
+    controller.abort();
+    fallbackStatic();
+    return;
+  }
+
+  const ambientLight = new THREE.AmbientLight(0x14253b, 0.55);
+  scene.add(ambientLight);
+
+  const keyLight = new THREE.DirectionalLight(0x7fd4ff, 1.3);
+  keyLight.position.set(3, 4.5, 5.5);
+  scene.add(keyLight);
+
+  const rimLight = new THREE.DirectionalLight(0xff8bdc, 0.65);
+  rimLight.position.set(-4, -2.5, -4);
+  scene.add(rimLight);
+
+  const fillLight = new THREE.PointLight(0x35c6ff, 0.9, 6, 2);
+  fillLight.position.set(-0.4, 1.8, 1.5);
+  scene.add(fillLight);
+
+  const knotGeometry = new THREE.TorusKnotGeometry(0.9, 0.32, 240, 32, 2, 3);
+  const knotMaterial = new THREE.MeshPhysicalMaterial({
+    color: 0x44dfff,
+    emissive: 0x082a3f,
+    emissiveIntensity: 0.22,
+    metalness: 0.5,
+    roughness: 0.14,
+    transmission: 0.6,
+    thickness: 1.35,
+    clearcoat: 1,
+    clearcoatRoughness: 0.06,
+    sheen: 0.75,
+    sheenRoughness: 0.4,
+    iridescence: 0.25,
+    iridescenceIOR: 1.15,
+    reflectivity: 0.75,
+    envMapIntensity: 1.3,
+  });
+  const knot = new THREE.Mesh(knotGeometry, knotMaterial);
+  knot.castShadow = false;
+  knot.receiveShadow = false;
+  group.add(knot);
+  resources.push(knotGeometry, knotMaterial);
+
+  const platformGeometry = new THREE.CylinderGeometry(1.25, 1.45, 0.18, 64);
+  const platformMaterial = new THREE.MeshStandardMaterial({
+    color: 0x0b1629,
+    metalness: 0.7,
+    roughness: 0.85,
+    emissive: 0x041628,
+    emissiveIntensity: 0.45,
+  });
+  const platform = new THREE.Mesh(platformGeometry, platformMaterial);
+  platform.position.y = -1.35;
+  group.add(platform);
+  resources.push(platformGeometry, platformMaterial);
+
+  const haloGeometry = new THREE.RingGeometry(0.95, 1.55, 64);
+  const haloMaterial = new THREE.MeshBasicMaterial({
+    color: 0x0f3a64,
+    opacity: 0.6,
+    transparent: true,
+  });
+  const halo = new THREE.Mesh(haloGeometry, haloMaterial);
+  halo.rotation.x = -Math.PI / 2;
+  halo.position.y = -1.45;
+  group.add(halo);
+  resources.push(haloGeometry, haloMaterial);
+
+  const composer = new EffectComposer(renderer);
+  const renderPass = new RenderPass(scene, camera);
+  composer.addPass(renderPass);
+
+  const bloomPass = new UnrealBloomPass(new THREE.Vector2(1, 1), 1.05, 0.6, 0.6);
+  composer.addPass(bloomPass);
+
+  renderer.domElement.style.position = 'absolute';
+  renderer.domElement.style.inset = '0';
+  renderer.domElement.style.width = '100%';
+  renderer.domElement.style.height = '100%';
+  renderer.domElement.style.pointerEvents = 'none';
+  renderer.domElement.setAttribute('aria-hidden', 'true');
+
+  element.appendChild(renderer.domElement);
+  element.setAttribute('aria-disabled', 'false');
+  element.classList.add('cta3d--ready');
+
+  const baseRotation = { x: 0.52, y: -0.45 };
+  const state = {
+    reduceMotion: reduceMotionQuery.matches,
+    targetScale: 1,
+    currentScale: 1,
+    targetRotationX: baseRotation.x,
+    targetRotationY: baseRotation.y,
+    rotationX: baseRotation.x,
+    rotationY: baseRotation.y,
+  };
+
+  const updateReducedMotion = (matches) => {
+    state.reduceMotion = matches;
+    if (matches) {
+      state.targetScale = 1;
+      bloomPass.strength = 0.45;
+      element.classList.add('cta3d--reduced-motion');
+    } else {
+      bloomPass.strength = 1.05;
+      element.classList.remove('cta3d--reduced-motion');
+    }
+  };
+  updateReducedMotion(state.reduceMotion);
+
+  reduceMotionQuery.addEventListener(
+    'change',
+    (event) => {
+      updateReducedMotion(event.matches);
+    },
+    { signal }
+  );
+
+  const pointerState = { inside: false };
+
+  const handlePointerEnter = () => {
+    pointerState.inside = true;
+    element.classList.add('cta3d--active');
+    if (!state.reduceMotion) {
+      state.targetScale = 1.08;
+    }
+  };
+
+  const resetPointer = () => {
+    pointerState.inside = false;
+    element.classList.remove('cta3d--active');
+    state.targetScale = 1;
+    state.targetRotationX = baseRotation.x;
+    state.targetRotationY = baseRotation.y;
+  };
+
+  const handlePointerMove = (event) => {
+    if (!pointerState.inside || state.reduceMotion) {
+      return;
+    }
+    const rect = element.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return;
+    }
+    const normX = (event.clientX - rect.left) / rect.width;
+    const normY = (event.clientY - rect.top) / rect.height;
+    const targetX = baseRotation.x + (0.5 - normY) * 0.5;
+    const targetY = baseRotation.y + (normX - 0.5) * 0.8;
+    state.targetRotationX = THREE.MathUtils.clamp(targetX, baseRotation.x - 0.4, baseRotation.x + 0.4);
+    state.targetRotationY = THREE.MathUtils.clamp(targetY, baseRotation.y - 0.6, baseRotation.y + 0.6);
+  };
+
+  element.addEventListener('pointerenter', handlePointerEnter, { signal });
+  element.addEventListener('pointerleave', resetPointer, { signal });
+  element.addEventListener('pointermove', handlePointerMove, { signal, passive: true });
+
+  element.addEventListener(
+    'focus',
+    () => {
+      element.classList.add('cta3d--active');
+      if (!state.reduceMotion) {
+        state.targetScale = 1.08;
+      }
+    },
+    { signal }
+  );
+
+  element.addEventListener(
+    'blur',
+    () => {
+      element.classList.remove('cta3d--active');
+      state.targetScale = 1;
+      state.targetRotationX = baseRotation.x;
+      state.targetRotationY = baseRotation.y;
+    },
+    { signal }
+  );
+
+  const resizeRenderer = () => {
+    const rect = element.getBoundingClientRect();
+    const width = Math.max(rect.width, 1);
+    const height = Math.max(rect.height, 1);
+    renderer.setSize(width, height, false);
+    composer.setSize(width, height);
+    bloomPass.setSize(width, height);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  };
+
+  let resizeObserver;
+  if ('ResizeObserver' in window) {
+    resizeObserver = new ResizeObserver(() => resizeRenderer());
+    resizeObserver.observe(element);
+  } else {
+    window.addEventListener('resize', resizeRenderer, { signal });
+  }
+  resizeRenderer();
+
+  const clock = new THREE.Clock();
+  let rafId = 0;
+  let running = false;
+
+  const renderFrame = () => {
+    if (!running) {
+      return;
+    }
+    rafId = window.requestAnimationFrame(renderFrame);
+    const delta = clock.getDelta();
+
+    if (!state.reduceMotion) {
+      knot.rotation.y += delta * 0.6;
+      knot.rotation.x += delta * 0.35;
+      halo.material.opacity = 0.5 + Math.sin(clock.elapsedTime * 1.5) * 0.1;
+    }
+
+    state.rotationX += (state.targetRotationX - state.rotationX) * 0.08;
+    state.rotationY += (state.targetRotationY - state.rotationY) * 0.08;
+    group.rotation.x = state.rotationX;
+    group.rotation.y = state.rotationY;
+
+    state.currentScale += (state.targetScale - state.currentScale) * 0.08;
+    group.scale.setScalar(state.currentScale);
+
+    composer.render();
+  };
+
+  const start = () => {
+    if (running) {
+      return;
+    }
+    running = true;
+    clock.start();
+    rafId = window.requestAnimationFrame(renderFrame);
+  };
+
+  const stop = () => {
+    if (!running) {
+      return;
+    }
+    running = false;
+    window.cancelAnimationFrame(rafId);
+  };
+
+  let intersectionObserver;
+  if ('IntersectionObserver' in window) {
+    intersectionObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.target !== element) {
+            return;
+          }
+          if (entry.isIntersecting) {
+            start();
+          } else {
+            stop();
+          }
+        });
+      },
+      { threshold: 0.15 }
+    );
+
+    intersectionObserver.observe(element);
+  } else {
+    start();
+  }
+
+  const mutationObserver = new MutationObserver(() => {
+    if (!element.isConnected) {
+      cleanup();
+    }
+  });
+  mutationObserver.observe(document.body, { childList: true, subtree: true });
+
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) {
+      return;
+    }
+    cleaned = true;
+
+    if (!signal.aborted) {
+      controller.abort();
+    }
+
+    stop();
+    if (intersectionObserver) {
+      intersectionObserver.disconnect();
+    }
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+    }
+    mutationObserver.disconnect();
+
+    element.classList.remove('cta3d--ready', 'cta3d--active', 'cta3d--fallback');
+
+    if (renderer.domElement.parentElement === element) {
+      element.removeChild(renderer.domElement);
+    }
+
+    resources.forEach((resource) => {
+      if (resource && typeof resource.dispose === 'function') {
+        resource.dispose();
+      }
+    });
+
+    if (envTarget) {
+      envTarget.dispose();
+    }
+    if (pmremGenerator) {
+      pmremGenerator.dispose();
+    }
+    if (composer.dispose) {
+      composer.dispose();
+    } else {
+      if (composer.renderTarget1) {
+        composer.renderTarget1.dispose();
+      }
+      if (composer.renderTarget2) {
+        composer.renderTarget2.dispose();
+      }
+    }
+    renderer.dispose();
+    if (renderer.forceContextLoss) {
+      renderer.forceContextLoss();
+    }
+  };
+
+  signal.addEventListener('abort', cleanup);
+
+  start();
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -221,9 +221,19 @@ body.site-frame {
   text-align: center;
 }
 
+.portal-links .cta3d {
+  flex: 1 1 clamp(180px, 28vw, 240px);
+  max-width: 260px;
+}
+
 @media (max-width: 600px) {
   .portal-links {
     flex-direction: column;
+  }
+
+  .portal-links .cta3d {
+    max-width: none;
+    width: 100%;
   }
 
   .hero {
@@ -236,6 +246,151 @@ body.site-frame {
   0% { background-position: 0% 50%; }
   50% { background-position: 100% 50%; }
   100% { background-position: 0% 50%; }
+}
+
+.cta3d {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 5.75rem;
+  padding: 0;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: radial-gradient(circle at 20% 20%, rgba(1, 205, 254, 0.28), transparent 55%),
+    radial-gradient(circle at 80% 80%, rgba(255, 113, 206, 0.35), transparent 60%),
+    linear-gradient(135deg, rgba(7, 23, 46, 0.8), rgba(3, 8, 18, 0.95));
+  box-shadow: 0 18px 30px rgba(4, 9, 24, 0.55), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+  isolation: isolate;
+  color: var(--fg);
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.45s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.45s cubic-bezier(0.16, 1, 0.3, 1);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+.cta3d::after {
+  content: attr(data-label);
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(1rem, 2.4vw, 1.35rem);
+  letter-spacing: 0.32em;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #e9f6ff;
+  text-shadow: 0 0 16px rgba(1, 205, 254, 0.6), 0 0 32px rgba(255, 113, 206, 0.4);
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+  z-index: 1;
+}
+
+.cta3d canvas {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  filter: saturate(1.15) contrast(1.05);
+}
+
+.cta3d__label {
+  position: relative;
+  z-index: 2;
+  font-size: clamp(1rem, 2.4vw, 1.25rem);
+  letter-spacing: 0.32em;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #f6fbff;
+  text-shadow: 0 0 18px rgba(1, 205, 254, 0.75), 0 0 28px rgba(255, 113, 206, 0.5);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.45s ease, transform 0.45s ease;
+  pointer-events: none;
+}
+
+.cta3d:hover,
+.cta3d:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: 0 22px 40px rgba(3, 10, 29, 0.65), 0 0 28px rgba(1, 205, 254, 0.35);
+}
+
+.cta3d:focus {
+  outline: none;
+}
+
+.cta3d:focus-visible {
+  outline: 3px solid rgba(1, 205, 254, 0.8);
+  outline-offset: 4px;
+}
+
+.cta3d--ready::after {
+  opacity: 0;
+}
+
+.cta3d--ready .cta3d__label {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.cta3d--fallback::after {
+  opacity: 1;
+}
+
+.cta3d--fallback .cta3d-fallback-link {
+  font-size: clamp(1rem, 2.4vw, 1.35rem);
+  letter-spacing: 0.32em;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.cta3d--active {
+  box-shadow: 0 24px 48px rgba(2, 9, 26, 0.7), 0 0 36px rgba(255, 113, 206, 0.4);
+}
+
+.cta3d[aria-disabled='true'] {
+  opacity: 0.92;
+  box-shadow: 0 16px 28px rgba(4, 9, 24, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.cta3d[aria-disabled='true']:hover,
+.cta3d[aria-disabled='true']:focus-visible {
+  transform: none;
+  box-shadow: 0 18px 30px rgba(4, 9, 24, 0.55), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.cta3d--reduced-motion {
+  transition: box-shadow 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cta3d,
+  .cta3d__label {
+    transition: none;
+  }
+
+  .cta3d:hover,
+  .cta3d:focus-visible {
+    transform: none;
+  }
+}
+
+.cta3d-fallback-link {
+  position: relative;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: inherit;
+  text-decoration: none;
 }
 
 @keyframes ctaPulse {
@@ -599,6 +754,103 @@ footer:focus-within {
 
 .logo-link {
   margin-right: var(--space-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(1, 205, 254, 0.25), rgba(255, 113, 206, 0.18));
+  box-shadow: 0 12px 20px rgba(5, 12, 33, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.logo-link:focus-visible,
+.logo-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(3, 10, 29, 0.55), 0 0 18px rgba(1, 205, 254, 0.35);
+}
+
+.logo-link:focus-visible {
+  outline: 2px solid rgba(1, 205, 254, 0.7);
+  outline-offset: 3px;
+}
+
+.logo {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  line-height: 1;
+  color: var(--fg);
+  text-transform: none;
+}
+
+.logo-word {
+  position: relative;
+  display: inline-block;
+  font-size: clamp(1.5rem, 4vw, 2.4rem);
+  letter-spacing: 0.45em;
+  font-weight: 700;
+  color: #f4fbff;
+  text-shadow: 0 0 22px rgba(1, 205, 254, 0.65);
+  padding-right: 0.2em;
+  overflow: hidden;
+}
+
+.logo-word::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -120%;
+  width: 120%;
+  height: 100%;
+  background: linear-gradient(110deg, transparent 10%, rgba(255, 255, 255, 0.75) 45%, transparent 80%);
+  transform: skewX(-18deg);
+  animation: shine 4.5s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+.logo-pronounce {
+  font-size: clamp(0.7rem, 1.8vw, 0.85rem);
+  letter-spacing: 0.28em;
+  font-weight: 500;
+  color: rgba(233, 246, 255, 0.8);
+  text-transform: none;
+  opacity: 0.9;
+}
+
+@keyframes shine {
+  0% {
+    transform: translateX(0) skewX(-18deg);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  45% {
+    transform: translateX(180%) skewX(-18deg);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(180%) skewX(-18deg);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .logo-link {
+    transition: none;
+  }
+
+  .logo-link:hover,
+  .logo-link:focus-visible {
+    transform: none;
+  }
+
+  .logo-word::before {
+    animation: none;
+    opacity: 0;
+  }
 }
 
 .header-center {

--- a/includes/header.php
+++ b/includes/header.php
@@ -49,6 +49,10 @@ endif;
     <a href="/index.php" class="logo-link">
       <img class="logo-img" src="/assets/logo.png" alt="SkuzE Logo">
     </a>
+    <h1 class="logo">
+      <span class="logo-word">SKUZE</span>
+      <span class="logo-pronounce">sk-uh-zee</span>
+    </h1>
     <nav class="site-nav">
       <a href="/index.php" data-i18n="home">Home</a>
       <a href="/about.php" data-i18n="about">About</a>

--- a/includes/layout.php
+++ b/includes/layout.php
@@ -8,3 +8,4 @@ $theme = 'light';
     document.documentElement.dataset.theme = localStorage.getItem('theme') || document.documentElement.dataset.theme;
   </script>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap">
+  <script type="module" src="/assets/3d-buttons.js" defer></script>

--- a/index.php
+++ b/index.php
@@ -26,10 +26,9 @@ session_start();
       <div class="hero-content">
         <p class="tagline">Fix, buy, sell, or trade your electronics in one place.</p>
         <div class="portal-links">
-          <?= render_button('services.php', 'Services'); ?>
-          <?= render_button('buy.php', 'Buy'); ?>
-          <?= render_button('sell.php', 'Sell'); ?>
-          <?= render_button('trade.php', 'Trade'); ?>
+          <div class="cta3d" data-label="Services" data-url="/services.php"></div>
+          <div class="cta3d" data-label="Buy" data-url="/buy.php"></div>
+          <div class="cta3d" data-label="Trade" data-url="/trade.php"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace the hero CTA buttons with progressive-enhancement 3D canvases that keep a gradient/text fallback and wire up keyboard, hover, reduced-motion, and URL handling
- load a new Three.js module that renders glassy torus knots with bloom, pointer parallax, resize/intersection management, and graceful cleanup or fallback when WebGL is unavailable
- refresh header branding by adding the animated SKUZE wordmark/pronunciation and styling updates for the logo link, shine effect, and CTA container states

## Testing
- php -l index.php
- php -l includes/header.php

------
https://chatgpt.com/codex/tasks/task_e_68cbcc577c44832ba8456eca61c2fb7c