### PR TITLE
Add AdSense script to head sections

### DIFF
--- a/admin/products.php
+++ b/admin/products.php
@@ -28,6 +28,8 @@ $products = $conn->query('SELECT sku, title, quantity, reorder_threshold, owner_
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3601799131755099"
+        crossorigin="anonymous"></script>
     <title>Admin - Products</title>
     <link rel="stylesheet" href="../assets/style.css">
 </head>

--- a/cart.php
+++ b/cart.php
@@ -67,6 +67,8 @@ $grand_total = $total + $tax + $shipping;
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3601799131755099"
+        crossorigin="anonymous"></script>
     <title>Your Cart</title>
     <link rel="stylesheet" href="assets/style.css">
 </head>

--- a/includes/layout.php
+++ b/includes/layout.php
@@ -4,6 +4,8 @@ $theme = 'light';
 <!DOCTYPE html>
 <html lang="en" data-theme="<?= htmlspecialchars($theme, ENT_QUOTES, 'UTF-8'); ?>">
 <head>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3601799131755099"
+      crossorigin="anonymous"></script>
   <script>
     document.documentElement.dataset.theme = localStorage.getItem('theme') || document.documentElement.dataset.theme;
   </script>


### PR DESCRIPTION
## Summary
- inject the Google AdSense script into the shared layout head so it appears across site pages
- add the same script to standalone pages with their own head sections, including the cart and admin products pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbd49d2a64832b8c356d22d91bd7e2