### PR TITLE
Fix database handle usage and unread helper

### DIFF
--- a/includes/db.php
+++ b/includes/db.php
@@ -39,6 +39,12 @@ try {
     $mysqli = new mysqli($host, $user, $pass, $db, $port);
   }
   $mysqli->set_charset('utf8mb4');
+
+  /* Back-compat for legacy code expecting $conn */
+  if (!isset($conn) || !($conn instanceof mysqli)) {
+    $conn = $mysqli;
+  }
+
   return $mysqli;
 } catch (mysqli_sql_exception $e) {
   error_log(sprintf('[db.php] Connect failed: %s | host=%s port=%d socket=%s',

--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 require_once __DIR__ . '/db.php';
 
 /**
@@ -74,16 +76,19 @@ function count_unread_notifications($conn, $user_id) {
     return 0;
 }
 
-function count_unread_messages($conn, $user_id) {
-    if ($stmt = $conn->prepare('SELECT COUNT(*) FROM messages WHERE recipient_id = ? AND read_at IS NULL')) {
-        $stmt->bind_param('i', $user_id);
+function count_unread_messages(mysqli $db, int $userId): int {
+    if ($userId <= 0) return 0;
+    $sql = "SELECT COUNT(*) FROM message_requests WHERE recipient_id = ? AND read_at IS NULL";
+    $stmt = $db->prepare($sql);
+    try {
+        $stmt->bind_param('i', $userId);
         $stmt->execute();
         $stmt->bind_result($count);
         $stmt->fetch();
+        return (int)$count;
+    } finally {
         $stmt->close();
-        return $count;
     }
-    return 0;
 }
 
 


### PR DESCRIPTION
## Summary
- add a legacy `$conn` alias after establishing the mysqli connection
- update the unread message counter helper to require an injected mysqli handle and close statements safely
- have the header bootstrap auth/db dependencies, derive the current user id, and call the helper with logging on failure

## Testing
- php -l includes/db.php
- php -l includes/notifications.php
- php -l includes/header.php

------
https://chatgpt.com/codex/tasks/task_e_68cbd6126160832ba948f975259dfcad