### PR TITLE
Guard session usage across entry points

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,4 +1,4 @@
-<?php session_start(); ?>
+<?php require_once __DIR__ . '/includes/auth.php'; ?>
 <?php require 'includes/layout.php'; ?>
   <meta charset="UTF-8">
   <title>About SkuzE</title>

--- a/admin/discount-codes.php
+++ b/admin/discount-codes.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/db.php';
 require '../includes/csrf.php';
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/db.php';
 require '../includes/user.php';
 

--- a/admin/listings.php
+++ b/admin/listings.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/db.php';
 require '../includes/user.php';
 require '../includes/csrf.php';

--- a/admin/order.php
+++ b/admin/order.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/orders.php';
 
 if (empty($_SESSION['is_admin'])) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/orders.php';
 
 if (empty($_SESSION['is_admin'])) {

--- a/admin/products.php
+++ b/admin/products.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 if (!$_SESSION['is_admin']) {
     header('Location: /index.php');
     exit;

--- a/admin/support.php
+++ b/admin/support.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/db.php';
 require '../includes/csrf.php';
 require '../includes/support.php';

--- a/admin/theme.php
+++ b/admin/theme.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 
 if (!$_SESSION['is_admin']) {
   header("Location: ../dashboard.php");

--- a/admin/toolbox.php
+++ b/admin/toolbox.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/csrf.php';
 
 if (!$_SESSION['is_admin']) {

--- a/admin/trade-requests.php
+++ b/admin/trade-requests.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/db.php';
 require '../includes/user.php';
 

--- a/admin/user-edit.php
+++ b/admin/user-edit.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/db.php';
 require '../includes/user.php';
 require '../includes/csrf.php';

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/db.php';
 require '../includes/user.php';
 require '../includes/csrf.php';

--- a/admin/view.php
+++ b/admin/view.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/db.php';
 require '../includes/csrf.php';
 require '../includes/user.php';

--- a/auth.php
+++ b/auth.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
 require_once 'db.php';
 
 if (!isset($_SESSION['user_id'])) {

--- a/buy-step.php
+++ b/buy-step.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/csrf.php';
 
 $category = $_GET['category'] ?? '';

--- a/buy.php
+++ b/buy.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/tags.php';

--- a/cancel.php
+++ b/cancel.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 require __DIR__ . '/_debug_bootstrap.php';
-require __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 ?>
 <?php require 'includes/layout.php'; ?>
   <title>Payment Canceled</title>

--- a/cart.php
+++ b/cart.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
 require_once 'includes/db.php';
 
 if (!isset($_SESSION['cart'])) {

--- a/checkout.php
+++ b/checkout.php
@@ -3,7 +3,7 @@ require __DIR__ . '/_debug_bootstrap.php';
 $client = require __DIR__ . '/includes/square.php';
 $squareConfig = require __DIR__ . '/includes/square-config.php';
 require 'includes/requirements.php';
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/url.php';
 

--- a/checkout_process.php
+++ b/checkout_process.php
@@ -11,7 +11,7 @@ require __DIR__ . '/_debug_bootstrap.php';
  *   - listing_id          (int) server computes price
  */
 
-require __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 $maybeDb = require __DIR__ . '/includes/db.php';  // may return mysqli OR set $conn/$mysqli
 $config  = require __DIR__ . '/config.php';
 

--- a/compose-message.php
+++ b/compose-message.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/notifications.php';

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/notifications.php';
 require 'includes/orders.php';

--- a/edit-profile.php
+++ b/edit-profile.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/csrf.php';
 
 $userId = $_SESSION['user_id'];

--- a/escrow.php
+++ b/escrow.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/followers.php
+++ b/followers.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/user.php';
 
 $id = $_SESSION['user_id'];

--- a/forum/index.php
+++ b/forum/index.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/csrf.php';
 require '../includes/user.php';
 

--- a/forum/thread.php
+++ b/forum/thread.php
@@ -1,5 +1,5 @@
 <?php
-require '../includes/auth.php';
+require_once __DIR__ . '/../includes/auth.php';
 require '../includes/csrf.php';
 require '../includes/user.php';
 

--- a/friend-requests.php
+++ b/friend-requests.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/csrf.php';
 require 'includes/user.php';
 require 'includes/notifications.php';

--- a/friend-search.php
+++ b/friend-search.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/csrf.php';
 require 'includes/user.php';
 require 'includes/notifications.php';

--- a/help.php
+++ b/help.php
@@ -1,4 +1,4 @@
-<?php session_start(); ?>
+<?php require_once __DIR__ . '/includes/auth.php'; ?>
 <?php require 'includes/layout.php'; ?>
   <meta charset="UTF-8">
   <title>Help & FAQ</title>

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,20 +1,24 @@
 <?php
 declare(strict_types=1);
 
-if (session_status() !== PHP_SESSION_ACTIVE) {
-    session_start();
-}
+if (!defined('AUTH_BOOTSTRAPPED')) {
+    define('AUTH_BOOTSTRAPPED', true);
 
-$db = require __DIR__ . '/db.php';
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
 
-if (!isset($_SESSION['user_id'])) {
-  // Redirect to the login page at the site root
-  header("Location: /login.php");
-  exit;
-}
+    $db = require __DIR__ . '/db.php';
 
-// Optional: update last_active for online tracking
-if ($db instanceof mysqli) {
-  $db->query("UPDATE users SET last_active = NOW() WHERE id = " . intval($_SESSION['user_id']));
+    if (!isset($_SESSION['user_id'])) {
+        // Redirect to the login page at the site root
+        header("Location: /login.php");
+        exit;
+    }
+
+    // Optional: update last_active for online tracking
+    if ($db instanceof mysqli) {
+        $db->query("UPDATE users SET last_active = NOW() WHERE id = " . intval($_SESSION['user_id']));
+    }
 }
 ?>

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 require __DIR__ . '/_debug_bootstrap.php';
-session_start();
+require_once __DIR__ . '/includes/auth.php';
 ?>
 <?php require 'includes/layout.php'; ?>
 <?php require 'includes/components.php'; ?>

--- a/listing-delete.php
+++ b/listing-delete.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/listing.php
+++ b/listing.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/tags.php';

--- a/logout.php
+++ b/logout.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+require_once __DIR__ . '/includes/auth.php';
+
 session_destroy();
 header("Location: login.php");
 exit;

--- a/message-requests.php
+++ b/message-requests.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 
 $user_id = $_SESSION['user_id'];

--- a/message-thread.php
+++ b/message-thread.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/support.php';
 

--- a/messages.php
+++ b/messages.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 
 $user_id = $_SESSION['user_id'];

--- a/my-listings.php
+++ b/my-listings.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/tags.php';

--- a/my-requests.php
+++ b/my-requests.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 
 $id = $_SESSION['user_id'];

--- a/notifications.php
+++ b/notifications.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require_once 'includes/notifications.php';
 
 $user_id = $_SESSION['user_id'];

--- a/order.php
+++ b/order.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/orders.php';
 
 $orderId = isset($_GET['id']) ? (int) $_GET['id'] : 0;

--- a/privacy.php
+++ b/privacy.php
@@ -1,4 +1,4 @@
-<?php session_start(); ?>
+<?php require_once __DIR__ . '/includes/auth.php'; ?>
 <?php require 'includes/layout.php'; ?>
   <meta charset="UTF-8">
   <title>Privacy Policy</title>

--- a/profile.php
+++ b/profile.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/totp.php';

--- a/sell-step.php
+++ b/sell-step.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/csrf.php';
 
 $category = $_GET['category'] ?? '';

--- a/sell.php
+++ b/sell.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/tags.php';

--- a/service-step.php
+++ b/service-step.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/csrf.php';
 
 // Service requests now have a dedicated step handler. Buy, sell and trade

--- a/services.php
+++ b/services.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/csrf.php';
 require 'includes/db.php';
 ?>

--- a/shipping.php
+++ b/shipping.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/submit-request.php
+++ b/submit-request.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require_once 'mail.php';

--- a/success.php
+++ b/success.php
@@ -1,6 +1,6 @@
 <?php
 require __DIR__ . '/_debug_bootstrap.php';
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 ?>
 <?php require 'includes/layout.php'; ?>
   <title>Payment Success</title>

--- a/support.php
+++ b/support.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/csrf.php';
 require 'includes/support.php';
 

--- a/terms.php
+++ b/terms.php
@@ -1,4 +1,4 @@
-<?php session_start(); ?>
+<?php require_once __DIR__ . '/includes/auth.php'; ?>
 <?php require 'includes/layout.php'; ?>
   <meta charset="UTF-8">
   <title>Terms of Service</title>

--- a/trade-cancel.php
+++ b/trade-cancel.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/trade-fulfillment.php
+++ b/trade-fulfillment.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/notifications.php';

--- a/trade-listing-delete.php
+++ b/trade-listing-delete.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/trade-listing.php
+++ b/trade-listing.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/trade-listings.php
+++ b/trade-listings.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/user.php';
 require 'includes/csrf.php';

--- a/trade-offer-delete.php
+++ b/trade-offer-delete.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/trade-offer.php
+++ b/trade-offer.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/trade-step.php
+++ b/trade-step.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/csrf.php';
 
 $category = $_GET['category'] ?? '';

--- a/trade.php
+++ b/trade.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/update-request.php
+++ b/update-request.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/view-profile.php
+++ b/view-profile.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/csrf.php';
 require 'includes/notifications.php';
 require 'includes/components.php';

--- a/vip.php
+++ b/vip.php
@@ -1,5 +1,5 @@
 <?php
-require 'includes/auth.php';
+require_once __DIR__ . '/includes/auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 


### PR DESCRIPTION
## Summary
- require the guarded authentication bootstrap in entry points that previously called session_start() directly
- wrap the remaining public session usage in a session_status() check
- normalize auth bootstrap includes to use require_once with __DIR__ references across entry points

## Testing
- rg "includes/auth.php" -n

------
https://chatgpt.com/codex/tasks/task_e_68cc2c27c5c0832bb35f3d1796f56831