### PR TITLE
Guard session bootstrap against duplicate starts

### DIFF
--- a/includes/auth.php
+++ b/includes/auth.php
@@ -4,8 +4,23 @@ declare(strict_types=1);
 if (!defined('AUTH_BOOTSTRAPPED')) {
     define('AUTH_BOOTSTRAPPED', true);
 
-    if (session_status() !== PHP_SESSION_ACTIVE) {
+    $sessionStatus = session_status();
+
+    if ($sessionStatus === PHP_SESSION_ACTIVE) {
+        // Session is already active, so nothing else to bootstrap here.
+    } elseif ($sessionStatus === PHP_SESSION_NONE) {
+        if (headers_sent($sentFile, $sentLine)) {
+            trigger_error(
+                sprintf('Unable to start session because headers were sent in %s on line %d.', $sentFile, $sentLine),
+                E_USER_WARNING
+            );
+            return;
+        }
+
         session_start();
+    } else {
+        // Sessions are disabled; nothing to do.
+        return;
     }
 
     $db = require __DIR__ . '/db.php';

--- a/includes/csrf.php
+++ b/includes/csrf.php
@@ -1,6 +1,13 @@
 <?php
 if (session_status() === PHP_SESSION_NONE) {
-    session_start();
+    if (headers_sent($sentFile, $sentLine)) {
+        trigger_error(
+            sprintf('Unable to start session because headers were sent in %s on line %d.', $sentFile, $sentLine),
+            E_USER_WARNING
+        );
+    } else {
+        session_start();
+    }
 }
 
 function generate_token() {

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,7 +1,14 @@
 <?php
-if (session_status() === PHP_SESSION_NONE):
-  session_start();
-endif;
+if (session_status() === PHP_SESSION_NONE) {
+  if (headers_sent($sentFile, $sentLine)) {
+    trigger_error(
+      sprintf('Unable to start session because headers were sent in %s on line %d.', $sentFile, $sentLine),
+      E_USER_WARNING
+    );
+  } else {
+    session_start();
+  }
+}
 require_once __DIR__ . '/auth.php';
 $db = require __DIR__ . '/db.php';
 require_once __DIR__ . '/user.php';


### PR DESCRIPTION
## Summary
- ensure the authentication bootstrap only starts a session when none is active and gracefully handle headers already sent
- align other session-aware includes with the single-session bootstrap approach

## Testing
- php -l includes/auth.php
- php -l includes/csrf.php
- php -l includes/header.php

------
https://chatgpt.com/codex/tasks/task_e_68cc592a6c14832bb96728290a3bdc07