### PR TITLE
Allow guest pages to opt out of header auth

### DIFF
--- a/forgot.php
+++ b/forgot.php
@@ -4,6 +4,10 @@ require 'includes/db.php';
 // Mail helper lives in the project root
 require 'mail.php';
 
+if (!defined('HEADER_SKIP_AUTH')) {
+  define('HEADER_SKIP_AUTH', true);
+}
+
   if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!validate_token($_POST['csrf_token'] ?? '')) {
       $msg = "Invalid CSRF token.";

--- a/includes/header.php
+++ b/includes/header.php
@@ -9,7 +9,11 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
   }
 }
-require_once __DIR__ . '/auth.php';
+
+$headerRequiresAuth = !defined('HEADER_SKIP_AUTH') || HEADER_SKIP_AUTH !== true;
+if ($headerRequiresAuth) {
+  require_once __DIR__ . '/auth.php';
+}
 $db = require __DIR__ . '/db.php';
 require_once __DIR__ . '/user.php';
 require_once __DIR__ . '/notifications.php';

--- a/login.php
+++ b/login.php
@@ -3,6 +3,10 @@ require 'includes/csrf.php';
 require 'includes/db.php';
 require 'includes/totp.php';
 
+if (!defined('HEADER_SKIP_AUTH')) {
+  define('HEADER_SKIP_AUTH', true);
+}
+
 $ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
 $maxAttempts = 5;
 $lockout = 300; // seconds

--- a/register.php
+++ b/register.php
@@ -4,6 +4,10 @@ require 'includes/db.php';
 // Mail helper lives in the project root
 require 'mail.php';
 
+if (!defined('HEADER_SKIP_AUTH')) {
+  define('HEADER_SKIP_AUTH', true);
+}
+
 $user = '';
 $email = '';
 $isBusiness = false;

--- a/reset.php
+++ b/reset.php
@@ -2,6 +2,10 @@
 require 'includes/csrf.php';
 require 'includes/db.php';
 
+if (!defined('HEADER_SKIP_AUTH')) {
+  define('HEADER_SKIP_AUTH', true);
+}
+
 $token = $_GET['token'] ?? '';
 $valid = false;
 

--- a/verify.php
+++ b/verify.php
@@ -1,6 +1,10 @@
 <?php
 require 'includes/db.php';
 
+if (!defined('HEADER_SKIP_AUTH')) {
+  define('HEADER_SKIP_AUTH', true);
+}
+
 $token = $_GET['token'] ?? '';
 if ($token) {
   $stmt = $conn->prepare("SELECT user_id, expires_at FROM tokens WHERE token = ? AND type = 'verify'");


### PR DESCRIPTION
## Summary
- gate the header's auth bootstrap behind a HEADER_SKIP_AUTH flag for guest views
- mark login, registration, password reset, and verification pages to skip header-driven auth redirects

## Testing
- php -l includes/header.php
- php -l login.php
- php -l register.php
- php -l forgot.php
- php -l reset.php
- php -l verify.php

------
https://chatgpt.com/codex/tasks/task_e_68ccb26b19dc832b90b4adf96c9cfb48