### PR TITLE
Implement services for listings, inventory, and order workflows

### DIFF
--- a/account/order_add_tracking.php
+++ b/account/order_add_tracking.php
@@ -1,16 +1,22 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/store.php';
 require_once __DIR__ . '/../includes/csrf.php';
 
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    http_response_code(405);
-    header('Content-Type: application/json');
-    echo json_encode(['success' => false, 'message' => 'Method not allowed.']);
+header('Content-Type: application/json');
+
+if (!authz_has_role('seller')) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Seller access required.']);
     exit;
 }
 
-header('Content-Type: application/json');
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Method not allowed.']);
+    exit;
+}
 
 if (!validate_token($_POST['csrf_token'] ?? '')) {
     echo json_encode(['success' => false, 'message' => 'Invalid request token.']);

--- a/account/order_update_status.php
+++ b/account/order_update_status.php
@@ -1,16 +1,22 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/store.php';
 require_once __DIR__ . '/../includes/csrf.php';
 
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    http_response_code(405);
-    header('Content-Type: application/json');
-    echo json_encode(['success' => false, 'message' => 'Method not allowed.']);
+header('Content-Type: application/json');
+
+if (!authz_has_role('seller')) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Seller access required.']);
     exit;
 }
 
-header('Content-Type: application/json');
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Method not allowed.']);
+    exit;
+}
 
 if (!validate_token($_POST['csrf_token'] ?? '')) {
     echo json_encode(['success' => false, 'message' => 'Invalid request token.']);

--- a/account/store.php
+++ b/account/store.php
@@ -1,7 +1,10 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/store.php';
 require_once __DIR__ . '/../includes/csrf.php';
+
+ensure_seller();
 
 $userId = (int) ($_SESSION['user_id'] ?? 0);
 $isAdmin = store_session_is_admin();

--- a/account/store_inventory_update.php
+++ b/account/store_inventory_update.php
@@ -1,16 +1,22 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/store.php';
 require_once __DIR__ . '/../includes/csrf.php';
 
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    http_response_code(405);
-    header('Content-Type: application/json');
-    echo json_encode(['success' => false, 'message' => 'Method not allowed.']);
+header('Content-Type: application/json');
+
+if (!authz_has_role('seller')) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Seller access required.']);
     exit;
 }
 
-header('Content-Type: application/json');
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Method not allowed.']);
+    exit;
+}
 
 if (!validate_token($_POST['csrf_token'] ?? '')) {
     echo json_encode(['success' => false, 'message' => 'Invalid request token.']);

--- a/admin/discount-codes.php
+++ b/admin/discount-codes.php
@@ -1,12 +1,10 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/csrf.php';
 
-if (!is_admin()) {
-  header('Location: ../dashboard.php');
-  exit;
-}
+ensure_admin('../dashboard.php');
 
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,12 +1,10 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/user.php';
 
-if (!is_admin()) {
-  header("Location: ../dashboard.php");
-  exit;
-}
+ensure_admin('../dashboard.php');
 
 $stmt = $conn->query("SELECT r.id, u.id AS user_id, u.username, r.category, r.issue, r.created_at, r.status
                       FROM service_requests r

--- a/admin/order-update.php
+++ b/admin/order-update.php
@@ -1,14 +1,12 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/orders.php';
 require '../includes/csrf.php';
 require '../includes/notifications.php';
 
-if (!is_admin()) {
-    header('Location: ../dashboard.php');
-    exit;
-}
+ensure_admin('../dashboard.php');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     header('Location: orders.php');

--- a/admin/order.php
+++ b/admin/order.php
@@ -1,12 +1,10 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/orders.php';
 require '../includes/csrf.php';
 
-if (!is_admin()) {
-    header('Location: ../dashboard.php');
-    exit;
-}
+ensure_admin('../dashboard.php');
 
 $orderId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 if ($orderId <= 0) {

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1,12 +1,10 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/orders.php';
 require '../includes/csrf.php';
 
-if (!is_admin()) {
-    header('Location: ../dashboard.php');
-    exit;
-}
+ensure_admin('../dashboard.php');
 
 $filter = $_GET['official'] ?? 'all';
 $officialOnly = null;

--- a/admin/products.php
+++ b/admin/products.php
@@ -1,12 +1,10 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/csrf.php';
 
-if (!is_admin() && !is_skuze_official()) {
-    header('Location: /index.php');
-    exit;
-}
+ensure_admin_or_official('/index.php');
 
 $statusMessage = '';
 $statusType = 'success';

--- a/admin/support.php
+++ b/admin/support.php
@@ -1,14 +1,12 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/csrf.php';
 require '../includes/support.php';
 require '../includes/user.php';
 
-if (!is_admin()) {
-    header('Location: ../dashboard.php');
-    exit;
-}
+ensure_admin('../dashboard.php');
 
 $statusFilter = $_GET['status'] ?? null;
 $allowedStatuses = ['open', 'pending', 'closed'];

--- a/admin/theme.php
+++ b/admin/theme.php
@@ -1,11 +1,9 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/theme_store.php';
 
-if (!is_admin()) {
-    header('Location: ../dashboard.php');
-    exit;
-}
+ensure_admin('../dashboard.php');
 
 $themePath = yoyo_theme_store_path();
 $dataDirectory = dirname($themePath);

--- a/admin/theme_save.php
+++ b/admin/theme_save.php
@@ -2,11 +2,12 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/theme_store.php';
 
 header('Content-Type: application/json');
 
-if (!is_admin()) {
+if (!authz_has_role('admin')) {
     http_response_code(403);
     echo json_encode(['status' => 'error', 'message' => 'Admin access required.']);
     exit;

--- a/admin/toolbox.php
+++ b/admin/toolbox.php
@@ -1,11 +1,9 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/csrf.php';
 
-if (!is_admin()) {
-  header('Location: ../dashboard.php');
-  exit;
-}
+ensure_admin('../dashboard.php');
 
 $toolsPath = __DIR__ . '/../assets/tools.json';
 $tools = [];

--- a/admin/trade-requests.php
+++ b/admin/trade-requests.php
@@ -1,12 +1,10 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/user.php';
 
-if (!is_admin()) {
-  header("Location: ../dashboard.php");
-  exit;
-}
+ensure_admin('../dashboard.php');
 
 $stmt = $conn->query("SELECT r.id, u.id AS user_id, u.username, r.make, r.model, r.device_type, r.created_at, r.status
                       FROM service_requests r

--- a/admin/user-edit.php
+++ b/admin/user-edit.php
@@ -1,13 +1,11 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/user.php';
 require '../includes/csrf.php';
 
-if (!is_admin()) {
-  header('Location: ../dashboard.php');
-  exit;
-}
+ensure_admin('../dashboard.php');
 
 $statuses = ['online', 'offline', 'busy', 'away']; // flair presets
 $id = (int)($_GET['id'] ?? 0);

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,13 +1,11 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/user.php';
 require '../includes/csrf.php';
 
-if (!is_admin()) {
-  header("Location: ../dashboard.php");
-  exit;
-}
+ensure_admin('../dashboard.php');
 
 $errors = [];
 $messages = [];

--- a/admin/view.php
+++ b/admin/view.php
@@ -1,14 +1,12 @@
 <?php
 require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/csrf.php';
 require '../includes/user.php';
 require '../includes/notifications.php';
 
-if (!is_admin()) {
-  header("Location: ../dashboard.php");
-  exit;
-}
+ensure_admin('../dashboard.php');
 
 $error = '';
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;

--- a/assets/shop-manager.js
+++ b/assets/shop-manager.js
@@ -1,0 +1,127 @@
+const managerRoot = document.querySelector('[data-shop-manager]');
+
+if (managerRoot) {
+  const services = window.ShopManagerServices || {};
+  const tabs = Array.from(managerRoot.querySelectorAll('[data-manager-tab]'));
+  const panels = new Map();
+  const mountedControllers = new Set();
+
+  tabs.forEach((tab) => {
+    const panelId = tab.getAttribute('aria-controls');
+    if (panelId) {
+      const panel = document.getElementById(panelId);
+      if (panel) {
+        panels.set(tab, panel);
+      }
+    }
+  });
+
+  const setActiveTab = (tabKey) => {
+    tabs.forEach((tab) => {
+      const key = tab.dataset.managerTab;
+      const isActive = key === tabKey;
+      tab.classList.toggle('is-active', isActive);
+      tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      const panel = panels.get(tab);
+      if (panel) {
+        panel.hidden = !isActive;
+        panel.classList.toggle('is-active', isActive);
+      }
+    });
+    if (tabKey) {
+      managerRoot.dataset.activeTab = tabKey;
+    }
+
+    const tabPanel = managerRoot.querySelector(`[data-manager-panel="${tabKey}"]`);
+    if (tabPanel) {
+      const repository = tabPanel.getAttribute('data-repository');
+      if (repository && !mountedControllers.has(repository)) {
+        const controller = services[repository];
+        if (controller && typeof controller.mount === 'function') {
+          try {
+            controller.mount(tabPanel, {
+              csrf: managerRoot.dataset.csrf || '',
+              container: managerRoot,
+            });
+            mountedControllers.add(repository);
+          } catch (error) {
+            console.error('Shop manager controller mount failed:', error);
+          }
+        }
+      }
+    }
+  };
+
+  const applyHistory = (tabKey) => {
+    if (!tabKey) {
+      return;
+    }
+    const url = new URL(window.location.href);
+    url.searchParams.set('tab', tabKey);
+    window.history.replaceState({ tab: tabKey }, '', url.toString());
+  };
+
+  const initialTab = managerRoot.dataset.activeTab || (tabs[0] && tabs[0].dataset.managerTab) || '';
+  if (initialTab) {
+    setActiveTab(initialTab);
+    applyHistory(initialTab);
+  }
+
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => {
+      const key = tab.dataset.managerTab;
+      if (!key) {
+        return;
+      }
+      setActiveTab(key);
+      applyHistory(key);
+      if (typeof services.onTabChange === 'function') {
+        try {
+          services.onTabChange(key, managerRoot);
+        } catch (error) {
+          console.error('Shop manager onTabChange failed:', error);
+        }
+      }
+    });
+  });
+
+  window.addEventListener('popstate', (event) => {
+    const stateTab = event.state && event.state.tab;
+    const urlTab = new URL(window.location.href).searchParams.get('tab');
+    const tabKey = stateTab || urlTab;
+    if (tabKey) {
+      setActiveTab(tabKey);
+    }
+  });
+
+  managerRoot.addEventListener('submit', (event) => {
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement)) {
+      return;
+    }
+    const panel = form.closest('[data-manager-panel]');
+    if (!panel) {
+      return;
+    }
+    const repository = panel.getAttribute('data-repository');
+    if (!repository) {
+      return;
+    }
+    const controller = services[repository];
+    if (!controller || typeof controller.handleAction !== 'function') {
+      return;
+    }
+    try {
+      const handled = controller.handleAction(form.dataset.managerAction || '', form, {
+        event,
+        csrf: managerRoot.dataset.csrf || '',
+        container: managerRoot,
+      });
+      if (handled === true) {
+        event.preventDefault();
+      }
+    } catch (error) {
+      console.error('Shop manager action handler failed:', error);
+    }
+  });
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -2614,6 +2614,164 @@ body.nav-open .hero {
   color: #ff6b6b;
 }
 
+.manager-panel__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin-bottom: var(--space-sm);
+}
+
+.manager-panel__title {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.manager-panel__description {
+  margin: var(--space-xs) 0 0;
+  color: rgba(255, 255, 255, 0.65);
+  max-width: 48rem;
+}
+
+.manager-panel__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: flex-end;
+}
+
+.manager-panel__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.manager-filter {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  font-size: 0.85rem;
+}
+
+.manager-filter__label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.7rem;
+}
+
+.manager-filter input,
+.manager-filter select {
+  min-width: 12rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.35);
+  color: inherit;
+}
+
+.manager-table .tag-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-xs);
+}
+
+.manager-tags {
+  min-width: 18rem;
+}
+
+.manager-tags__actions {
+  margin-top: var(--space-xs);
+}
+
+.manager-sync-status {
+  display: block;
+  margin-top: var(--space-xxs);
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #666);
+}
+
+.manager-pagination {
+  margin-top: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.manager-pagination ul {
+  display: flex;
+  gap: var(--space-xs);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.manager-pagination li {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.manager-pagination li.is-active {
+  border-color: var(--accent);
+}
+
+.manager-pagination a {
+  display: block;
+  padding: 0.3rem 0.8rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.manager-pagination a[aria-current="page"] {
+  background: rgba(155, 246, 255, 0.2);
+  color: var(--bg);
+}
+
+.manager-pagination__summary {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.manager-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.manager-settings fieldset {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  padding: var(--space-md);
+}
+
+.manager-settings legend {
+  padding: 0 0.4rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.manager-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: 0.95rem;
+}
+
+.manager-toggle input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.manager-toggle--disabled {
+  opacity: 0.6;
+}
+
 .table-wrapper {
   overflow-x: auto;
   border-radius: 10px;

--- a/config.example.php
+++ b/config.example.php
@@ -23,4 +23,5 @@ return [
   'square_location_id' => 'LXXXXXXXXXXXX',
   'square_access_token' => 'EAAAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
   'square_environment' => 'sandbox', // or 'production'
+  'SQUARE_CATALOG_SYNC' => false,
 ];

--- a/dashboard.php
+++ b/dashboard.php
@@ -60,7 +60,7 @@ $orders = fetch_orders_for_user($conn, (int) $id);
         <ul class="nav-links">
           <li><a class="btn" role="button" href="services.php">Start a Service Request</a></li>
           <li><a class="btn" role="button" href="my-requests.php">View My Service Requests</a></li>
-          <li><a class="btn" role="button" href="my-listings.php">Manage My Listings</a></li>
+          <li><a class="btn" role="button" href="shop-manager/index.php">Manage My Shop</a></li>
         </ul>
       </div>
       <div class="nav-section">

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -47,14 +47,49 @@ function auth_sync_user_context(mysqli $conn, int $userId): void
 {
     $role = 'user';
     $status = $_SESSION['status'] ?? null;
+    $vipStatus = $_SESSION['vip_status'] ?? null;
+    $vipExpiresAt = $_SESSION['vip_expires_at'] ?? null;
+    $accountType = $_SESSION['account_type'] ?? null;
 
-    if ($stmt = $conn->prepare('SELECT role, status FROM users WHERE id = ?')) {
+    $columns = ['role', 'status'];
+
+    if (auth_users_table_has_column($conn, 'vip_status')) {
+        $columns[] = 'vip_status';
+    }
+    if (auth_users_table_has_column($conn, 'vip_expires_at')) {
+        $columns[] = 'vip_expires_at';
+    }
+    if (auth_users_table_has_column($conn, 'account_type')) {
+        $columns[] = 'account_type';
+    }
+
+    $sql = 'SELECT ' . implode(', ', $columns) . ' FROM users WHERE id = ?';
+
+    if ($stmt = $conn->prepare($sql)) {
         $stmt->bind_param('i', $userId);
         if ($stmt->execute()) {
-            $stmt->bind_result($roleValue, $statusValue);
-            if ($stmt->fetch()) {
-                $role = $roleValue ?: 'user';
-                $status = $statusValue ?: $status;
+            if ($result = $stmt->get_result()) {
+                if ($row = $result->fetch_assoc()) {
+                    if (isset($row['role'])) {
+                        $role = $row['role'] ?: 'user';
+                    }
+                    if (isset($row['status']) && $row['status'] !== null) {
+                        $status = $row['status'];
+                    }
+                    if (array_key_exists('vip_status', $row)) {
+                        $vipStatus = $row['vip_status'];
+                        $_SESSION['vip_status'] = $vipStatus;
+                    }
+                    if (array_key_exists('vip_expires_at', $row)) {
+                        $vipExpiresAt = $row['vip_expires_at'];
+                        $_SESSION['vip_expires_at'] = $vipExpiresAt;
+                    }
+                    if (array_key_exists('account_type', $row)) {
+                        $accountType = $row['account_type'];
+                        $_SESSION['account_type'] = $accountType;
+                    }
+                }
+                $result->free();
             }
         }
         $stmt->close();
@@ -67,6 +102,38 @@ function auth_sync_user_context(mysqli $conn, int $userId): void
 
     // Maintain backwards compatibility for legacy checks until they are replaced.
     $_SESSION['is_admin'] = $role === 'admin' ? 1 : 0;
+
+    auth_refresh_session_roles([
+        'role' => $role,
+        'status' => $status,
+        'vip_status' => $vipStatus,
+        'vip_expires_at' => $vipExpiresAt,
+        'account_type' => $accountType,
+        'is_admin' => $_SESSION['is_admin'] ?? 0,
+    ]);
+}
+
+/**
+ * Determine if the requested column exists on the users table.
+ */
+function auth_users_table_has_column(mysqli $conn, string $column): bool
+{
+    static $columnCache = [];
+
+    if (array_key_exists($column, $columnCache)) {
+        return $columnCache[$column];
+    }
+
+    $escaped = $conn->real_escape_string($column);
+    $result = $conn->query("SHOW COLUMNS FROM users LIKE '" . $escaped . "'");
+    if ($result instanceof mysqli_result) {
+        $columnCache[$column] = $result->num_rows > 0;
+        $result->free();
+    } else {
+        $columnCache[$column] = false;
+    }
+
+    return $columnCache[$column];
 }
 
 if (!function_exists('current_user_id')) {
@@ -86,15 +153,96 @@ if (!function_exists('current_user_role')) {
 if (!function_exists('is_admin')) {
     function is_admin(): bool
     {
-        return current_user_role() === 'admin';
+        return in_array('admin', auth_current_roles(), true);
     }
 }
 
 if (!function_exists('is_skuze_official')) {
     function is_skuze_official(): bool
     {
-        $role = current_user_role();
+        return in_array('skuze_official', auth_current_roles(), true);
+    }
+}
 
-        return $role === 'skuze_official' || $role === 'admin';
+if (!function_exists('auth_refresh_session_roles')) {
+    /**
+     * Normalise the role set available to the current session.
+     *
+     * @param array<string, mixed> $context
+     *
+     * @return array<int, string>
+     */
+    function auth_refresh_session_roles(array $context = []): array
+    {
+        $role = strtolower((string) ($context['role'] ?? ($_SESSION['user_role'] ?? 'user')));
+        $status = strtolower((string) ($context['status'] ?? ($_SESSION['status'] ?? '')));
+        $vipStatus = $context['vip_status'] ?? ($_SESSION['vip_status'] ?? null);
+        $vipExpiresAt = $context['vip_expires_at'] ?? ($_SESSION['vip_expires_at'] ?? null);
+        $accountType = strtolower((string) ($context['account_type'] ?? ($_SESSION['account_type'] ?? '')));
+        $isAdminFlag = !empty($context['is_admin']) || !empty($_SESSION['is_admin']);
+
+        $roles = ['user'];
+
+        if ($role !== '') {
+            $roles[] = $role;
+        }
+
+        if ($isAdminFlag) {
+            $roles[] = 'admin';
+        }
+
+        if ($role === 'admin' || $isAdminFlag) {
+            $roles[] = 'skuze_official';
+            $roles[] = 'seller';
+        }
+
+        if ($role === 'skuze_official') {
+            $roles[] = 'skuze_official';
+            $roles[] = 'seller';
+        }
+
+        if ($accountType === 'business') {
+            $roles[] = 'seller';
+        }
+
+        $vipActive = false;
+        if ($vipStatus !== null) {
+            $vipActive = (int) $vipStatus === 1;
+            if ($vipActive && $vipExpiresAt) {
+                $expiresTs = strtotime((string) $vipExpiresAt);
+                if ($expiresTs !== false) {
+                    $vipActive = $expiresTs > time();
+                }
+            }
+        }
+
+        if ($vipActive) {
+            $roles[] = 'seller';
+        }
+
+        if (in_array($status, ['seller', 'vip', 'merchant', 'vendor'], true)) {
+            $roles[] = 'seller';
+        }
+
+        $roles = array_values(array_unique(array_map('strtolower', $roles)));
+        $_SESSION['auth_roles'] = $roles;
+
+        return $roles;
+    }
+}
+
+if (!function_exists('auth_current_roles')) {
+    /**
+     * Return the normalised role set for the active session.
+     *
+     * @return array<int, string>
+     */
+    function auth_current_roles(): array
+    {
+        if (isset($_SESSION['auth_roles']) && is_array($_SESSION['auth_roles'])) {
+            return array_values(array_unique(array_map('strtolower', $_SESSION['auth_roles'])));
+        }
+
+        return auth_refresh_session_roles();
     }
 }

--- a/includes/authz.php
+++ b/includes/authz.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/auth.php';
+
+/**
+ * Determine if the current session grants the requested role.
+ */
+function authz_has_role(string $role): bool
+{
+    $role = strtolower($role);
+
+    return in_array($role, auth_current_roles(), true);
+}
+
+/**
+ * Ensure the current session grants one of the permitted roles.
+ *
+ * @param array<int, string> $roles
+ */
+function require_role(array $roles, ?string $redirect = '/dashboard.php'): void
+{
+    $allowed = array_values(array_unique(array_map('strtolower', $roles)));
+    $currentRoles = auth_current_roles();
+
+    foreach ($allowed as $role) {
+        if (in_array($role, $currentRoles, true)) {
+            return;
+        }
+    }
+
+    if ($redirect !== null) {
+        if (!headers_sent()) {
+            header('Location: ' . $redirect);
+        }
+        exit;
+    }
+
+    http_response_code(403);
+    echo 'Access denied.';
+    exit;
+}
+
+function ensure_admin(?string $redirect = '/dashboard.php'): void
+{
+    require_role(['admin'], $redirect);
+}
+
+function ensure_official(?string $redirect = '/dashboard.php'): void
+{
+    require_role(['skuze_official'], $redirect);
+}
+
+function ensure_admin_or_official(?string $redirect = '/dashboard.php'): void
+{
+    require_role(['admin', 'skuze_official'], $redirect);
+}
+
+function ensure_seller(?string $redirect = '/vip.php?upgrade=1'): void
+{
+    require_role(['seller'], $redirect);
+}

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -13,7 +13,7 @@
       <h4>Account</h4>
       <ul>
         <li><a href="/dashboard.php">Dashboard</a></li>
-        <li><a href="/my-listings.php">My Listings</a></li>
+        <li><a href="/shop-manager/index.php">Shop Manager</a></li>
         <li><a href="/messages.php">Messages</a></li>
         <li><a href="/support.php">Support</a></li>
         <li><a href="/logout.php">Logout</a></li>

--- a/includes/repositories/ChangeRequestsService.php
+++ b/includes/repositories/ChangeRequestsService.php
@@ -1,0 +1,151 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/ShopLogger.php';
+
+final class ChangeRequestsService
+{
+    private mysqli $conn;
+
+    public function __construct(mysqli $conn)
+    {
+        $this->conn = $conn;
+    }
+
+    /**
+     * Persist a status change request for later moderation.
+     */
+    public function createStatusRequest(int $listingId, int $requesterId, string $requestedStatus, ?string $summary = null): ?int
+    {
+        if ($listingId <= 0 || $requesterId <= 0) {
+            return null;
+        }
+
+        $stmt = $this->conn->prepare(
+            'INSERT INTO listing_change_requests (listing_id, requester_id, change_type, change_summary, requested_status) '
+            . 'VALUES (?, ?, "status", ?, ?)' // change_type constrained to status for now
+        );
+
+        if ($stmt === false) {
+            shop_log('change_request.error', [
+                'listing_id' => $listingId,
+                'requester_id' => $requesterId,
+                'status' => $requestedStatus,
+                'error' => $this->conn->error,
+            ]);
+            return null;
+        }
+
+        $stmt->bind_param('iiss', $listingId, $requesterId, $summary, $requestedStatus);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            shop_log('change_request.error', [
+                'listing_id' => $listingId,
+                'requester_id' => $requesterId,
+                'status' => $requestedStatus,
+                'error' => $stmt->error,
+            ]);
+            return null;
+        }
+
+        $id = (int) $stmt->insert_id;
+        $stmt->close();
+
+        shop_log('change_request.created', [
+            'id' => $id,
+            'listing_id' => $listingId,
+            'requester_id' => $requesterId,
+            'status' => $requestedStatus,
+        ]);
+
+        return $id;
+    }
+
+    /**
+     * Mark pending requests for the listing as approved by the reviewer.
+     */
+    public function approveOpenRequests(int $listingId, int $reviewerId, string $status): int
+    {
+        return $this->resolveOpenRequests($listingId, $reviewerId, 'approved', $status);
+    }
+
+    /**
+     * Mark pending requests for the listing as rejected by the reviewer.
+     */
+    public function rejectOpenRequests(int $listingId, int $reviewerId, string $note = ''): int
+    {
+        return $this->resolveOpenRequests($listingId, $reviewerId, 'rejected', null, $note);
+    }
+
+    /**
+     * Cancel pending requests initiated by the requester.
+     */
+    public function cancelOpenRequests(int $listingId, int $requesterId): int
+    {
+        if ($listingId <= 0 || $requesterId <= 0) {
+            return 0;
+        }
+
+        $stmt = $this->conn->prepare(
+            'UPDATE listing_change_requests SET status = "cancelled", resolved_at = NOW(), updated_at = NOW() '
+            . 'WHERE listing_id = ? AND requester_id = ? AND status = "pending"'
+        );
+
+        if ($stmt === false) {
+            return 0;
+        }
+
+        $stmt->bind_param('ii', $listingId, $requesterId);
+        $stmt->execute();
+        $affected = $stmt->affected_rows;
+        $stmt->close();
+
+        if ($affected > 0) {
+            shop_log('change_request.cancelled', [
+                'listing_id' => $listingId,
+                'requester_id' => $requesterId,
+                'count' => $affected,
+            ]);
+        }
+
+        return $affected;
+    }
+
+    private function resolveOpenRequests(
+        int $listingId,
+        int $reviewerId,
+        string $resolution,
+        ?string $requestedStatus = null,
+        string $note = ''
+    ): int {
+        if ($listingId <= 0 || $reviewerId <= 0) {
+            return 0;
+        }
+
+        $stmt = $this->conn->prepare(
+            'UPDATE listing_change_requests '
+            . 'SET status = ?, reviewer_id = ?, resolved_at = NOW(), review_notes = ?, requested_status = COALESCE(requested_status, ?), updated_at = NOW() '
+            . 'WHERE listing_id = ? AND status = "pending"'
+        );
+
+        if ($stmt === false) {
+            return 0;
+        }
+
+        $stmt->bind_param('sissi', $resolution, $reviewerId, $note, $requestedStatus, $listingId);
+        $stmt->execute();
+        $affected = $stmt->affected_rows;
+        $stmt->close();
+
+        if ($affected > 0) {
+            shop_log('change_request.' . $resolution, [
+                'listing_id' => $listingId,
+                'reviewer_id' => $reviewerId,
+                'status' => $requestedStatus,
+                'count' => $affected,
+            ]);
+        }
+
+        return $affected;
+    }
+}

--- a/includes/repositories/InventoryService.php
+++ b/includes/repositories/InventoryService.php
@@ -1,0 +1,352 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/ShopLogger.php';
+require_once __DIR__ . '/ListingsRepo.php';
+
+final class InventoryService
+{
+    private mysqli $conn;
+
+    public function __construct(mysqli $conn)
+    {
+        $this->conn = $conn;
+    }
+
+    /**
+     * Apply an inventory delta against a product SKU with permission checks.
+     *
+     * @return array{sku: string, stock: int, quantity: ?int, reorder_threshold: int}
+     */
+    public function adjustProductStock(
+        string $sku,
+        int $delta,
+        int $actorId,
+        ?int $reorderThreshold,
+        bool $isAdmin,
+        bool $isOfficial
+    ): array {
+        if ($sku === '') {
+            throw new RuntimeException('A product SKU is required.');
+        }
+
+        $this->conn->begin_transaction();
+        try {
+            $stmt = $this->conn->prepare(
+                'SELECT owner_id, stock, quantity, reorder_threshold, is_skuze_official FROM products WHERE sku = ? FOR UPDATE'
+            );
+            if ($stmt === false) {
+                throw new RuntimeException('Unable to load inventory record.');
+            }
+            $stmt->bind_param('s', $sku);
+            if (!$stmt->execute()) {
+                $stmt->close();
+                throw new RuntimeException('Unable to load inventory record.');
+            }
+
+            $stmt->bind_result($ownerId, $stock, $quantity, $threshold, $isOfficialProduct);
+            if (!$stmt->fetch()) {
+                $stmt->close();
+                throw new RuntimeException('Inventory record not found.');
+            }
+            $stmt->close();
+
+            $ownerId = (int) $ownerId;
+            $currentStock = (int) $stock;
+            $currentQuantity = $quantity !== null ? (int) $quantity : null;
+            $currentThreshold = (int) $threshold;
+            $isOfficialProduct = (bool) $isOfficialProduct;
+
+            $canManage = $ownerId === $actorId || $isAdmin || ($isOfficial && $isOfficialProduct);
+            if (!$canManage) {
+                throw new RuntimeException('You do not have permission to adjust this inventory item.');
+            }
+
+            $newStock = max(0, $currentStock + $delta);
+            $newQuantity = $currentQuantity !== null ? max(0, $currentQuantity + $delta) : null;
+            $nextThreshold = $reorderThreshold ?? $currentThreshold;
+            if ($nextThreshold < 0) {
+                $nextThreshold = 0;
+            }
+
+            if ($currentQuantity !== null) {
+                $stmt = $this->conn->prepare('UPDATE products SET stock = ?, quantity = ?, reorder_threshold = ? WHERE sku = ?');
+                if ($stmt === false) {
+                    throw new RuntimeException('Unable to update inventory.');
+                }
+                $stmt->bind_param('iiis', $newStock, $newQuantity, $nextThreshold, $sku);
+            } else {
+                $stmt = $this->conn->prepare('UPDATE products SET stock = ?, reorder_threshold = ? WHERE sku = ?');
+                if ($stmt === false) {
+                    throw new RuntimeException('Unable to update inventory.');
+                }
+                $stmt->bind_param('iis', $newStock, $nextThreshold, $sku);
+            }
+
+            if (!$stmt->execute()) {
+                $stmt->close();
+                throw new RuntimeException('Failed to update inventory.');
+            }
+            $stmt->close();
+
+            $this->recordInventoryTransaction(
+                $sku,
+                $ownerId,
+                'manual_adjustment',
+                $delta,
+                $currentStock,
+                $newStock,
+                null,
+                null,
+                ['actor_id' => $actorId]
+            );
+
+            $this->conn->commit();
+
+            shop_log('inventory.adjusted', [
+                'sku' => $sku,
+                'actor_id' => $actorId,
+                'delta' => $delta,
+                'stock' => $newStock,
+            ]);
+
+            return [
+                'sku' => $sku,
+                'stock' => $newStock,
+                'quantity' => $newQuantity,
+                'reorder_threshold' => $nextThreshold,
+            ];
+        } catch (Throwable $e) {
+            $this->conn->rollback();
+            shop_log('inventory.error', [
+                'sku' => $sku,
+                'actor_id' => $actorId,
+                'error' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+    }
+
+    /**
+     * Reserve listing quantity while a checkout is in-flight.
+     *
+     * @return array{listing_id: int, reserved_qty: int, quantity: int}
+     */
+    public function reserveListing(int $listingId, int $quantity, int $actorId): array
+    {
+        if ($quantity <= 0) {
+            $quantity = 1;
+        }
+
+        $this->conn->begin_transaction();
+        try {
+            $repo = new ListingsRepo($this->conn);
+            $listing = $repo->fetchListing($listingId, true);
+            if (!$listing) {
+                throw new RuntimeException('Listing not found.');
+            }
+
+            $status = (string) ($listing['status'] ?? 'draft');
+            if (!in_array($status, ['approved', 'live'], true)) {
+                throw new RuntimeException('Listing is not available for reservation.');
+            }
+
+            $available = (int) $listing['quantity'] - (int) $listing['reserved_qty'];
+            if ($available < $quantity) {
+                throw new RuntimeException('Insufficient inventory for this listing.');
+            }
+
+            $stmt = $this->conn->prepare('UPDATE listings SET reserved_qty = reserved_qty + ?, updated_at = NOW() WHERE id = ?');
+            if ($stmt === false) {
+                throw new RuntimeException('Failed to reserve listing quantity.');
+            }
+
+            $stmt->bind_param('ii', $quantity, $listingId);
+            if (!$stmt->execute()) {
+                $stmt->close();
+                throw new RuntimeException('Failed to reserve listing quantity.');
+            }
+            $stmt->close();
+
+            $this->conn->commit();
+
+            shop_log('listing.reserved', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+                'quantity' => $quantity,
+            ]);
+
+            return [
+                'listing_id' => $listingId,
+                'reserved_qty' => (int) $listing['reserved_qty'] + $quantity,
+                'quantity' => (int) $listing['quantity'],
+            ];
+        } catch (Throwable $e) {
+            $this->conn->rollback();
+            shop_log('listing.reserve_error', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+                'error' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+    }
+
+    /**
+     * Release a reservation when checkout fails.
+     */
+    public function releaseListing(int $listingId, int $quantity, int $actorId): void
+    {
+        if ($quantity <= 0) {
+            return;
+        }
+
+        $this->conn->begin_transaction();
+        try {
+            $stmt = $this->conn->prepare('UPDATE listings SET reserved_qty = GREATEST(reserved_qty - ?, 0), updated_at = NOW() WHERE id = ?');
+            if ($stmt === false) {
+                throw new RuntimeException('Failed to release reservation.');
+            }
+            $stmt->bind_param('ii', $quantity, $listingId);
+            $stmt->execute();
+            $stmt->close();
+            $this->conn->commit();
+
+            shop_log('listing.reservation_released', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+                'quantity' => $quantity,
+            ]);
+        } catch (Throwable $e) {
+            $this->conn->rollback();
+            shop_log('listing.release_error', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+                'error' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+    }
+
+    /**
+     * Capture a reservation as fulfilled and decrement stock.
+     */
+    public function captureListing(int $listingId, int $quantity, int $actorId, ?int $referenceId = null): array
+    {
+        if ($quantity <= 0) {
+            $quantity = 1;
+        }
+
+        $this->conn->begin_transaction();
+        try {
+            $repo = new ListingsRepo($this->conn);
+            $listing = $repo->fetchListing($listingId, true);
+            if (!$listing) {
+                throw new RuntimeException('Listing not found.');
+            }
+
+            $reserved = (int) $listing['reserved_qty'];
+            if ($reserved < $quantity) {
+                throw new RuntimeException('Not enough reserved inventory to capture.');
+            }
+
+            $stmt = $this->conn->prepare('UPDATE listings SET reserved_qty = GREATEST(reserved_qty - ?, 0), quantity = GREATEST(quantity - ?, 0), updated_at = NOW() WHERE id = ?');
+            if ($stmt === false) {
+                throw new RuntimeException('Failed to update listing quantities.');
+            }
+            $stmt->bind_param('iii', $quantity, $quantity, $listingId);
+            if (!$stmt->execute()) {
+                $stmt->close();
+                throw new RuntimeException('Failed to update listing quantities.');
+            }
+            $stmt->close();
+
+            $productSku = $listing['product_sku'] ?? null;
+            $ownerId = (int) $listing['owner_id'];
+            $afterReserved = max(0, $reserved - $quantity);
+            $afterQuantity = max(0, (int) $listing['quantity'] - $quantity);
+
+            if ($productSku) {
+                $stmt = $this->conn->prepare('UPDATE products SET stock = GREATEST(stock - ?, 0), quantity = CASE WHEN quantity IS NULL THEN NULL ELSE GREATEST(quantity - ?, 0) END WHERE sku = ?');
+                if ($stmt !== false) {
+                    $stmt->bind_param('iis', $quantity, $quantity, $productSku);
+                    $stmt->execute();
+                    $stmt->close();
+                }
+
+                $this->recordInventoryTransaction(
+                    (string) $productSku,
+                    $ownerId,
+                    'sale_capture',
+                    -$quantity,
+                    null,
+                    null,
+                    'order',
+                    $referenceId,
+                    ['actor_id' => $actorId, 'listing_id' => $listingId]
+                );
+            }
+
+            $this->conn->commit();
+
+            shop_log('listing.reservation_captured', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+                'quantity' => $quantity,
+                'reserved_remaining' => $afterReserved,
+                'quantity_remaining' => $afterQuantity,
+            ]);
+
+            return [
+                'listing_id' => $listingId,
+                'reserved_qty' => $afterReserved,
+                'quantity' => $afterQuantity,
+            ];
+        } catch (Throwable $e) {
+            $this->conn->rollback();
+            shop_log('listing.capture_error', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+                'error' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+    }
+
+    private function recordInventoryTransaction(
+        string $sku,
+        int $ownerId,
+        string $type,
+        int $delta,
+        ?int $before,
+        ?int $after,
+        ?string $referenceType,
+        ?int $referenceId,
+        array $metadata
+    ): void {
+        $stmt = $this->conn->prepare(
+            'INSERT INTO inventory_transactions (product_sku, owner_id, transaction_type, quantity_change, quantity_before, quantity_after, reference_type, reference_id, metadata) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)' 
+        );
+
+        if ($stmt === false) {
+            return;
+        }
+
+        $json = $metadata ? json_encode($metadata, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : null;
+        $stmt->bind_param(
+            'sisiiisis',
+            $sku,
+            $ownerId,
+            $type,
+            $delta,
+            $before,
+            $after,
+            $referenceType,
+            $referenceId,
+            $json
+        );
+        $stmt->execute();
+        $stmt->close();
+    }
+}

--- a/includes/repositories/ListingsRepo.php
+++ b/includes/repositories/ListingsRepo.php
@@ -1,0 +1,461 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/ShopLogger.php';
+require_once __DIR__ . '/ChangeRequestsService.php';
+require_once __DIR__ . '/../tags.php';
+
+final class ListingsRepo
+{
+    private const STATUSES = ['draft','pending','approved','live','closed','delisted'];
+
+    private mysqli $conn;
+    private ChangeRequestsService $changeRequests;
+
+    /**
+     * Define allowed transitions between listing statuses.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private array $transitions = [
+        'draft' => ['pending', 'approved', 'live', 'delisted'],
+        'pending' => ['approved', 'delisted', 'draft'],
+        'approved' => ['live', 'closed', 'delisted'],
+        'live' => ['closed', 'delisted'],
+        'closed' => ['live', 'delisted'],
+        'delisted' => ['draft', 'pending', 'live'],
+    ];
+
+    public function __construct(mysqli $conn, ?ChangeRequestsService $changeRequests = null)
+    {
+        $this->conn = $conn;
+        $this->changeRequests = $changeRequests ?? new ChangeRequestsService($conn);
+    }
+
+    /**
+     * Create a new listing owned by the user.
+     *
+     * @param array<string, mixed> $data
+     * @return array{success: bool, listing_id?: int, status?: string, requires_review?: bool, error?: string}
+     */
+    public function create(int $ownerId, array $data, bool $autoApprove = false): array
+    {
+        if ($ownerId <= 0) {
+            return ['success' => false, 'error' => 'Invalid owner.'];
+        }
+
+        $title = trim((string) ($data['title'] ?? ''));
+        $description = trim((string) ($data['description'] ?? ''));
+        $condition = trim((string) ($data['condition'] ?? ''));
+        $price = (string) ($data['price'] ?? '0');
+        $category = $data['category'] ?? null;
+        $tagsStorage = $data['tags'] ?? null;
+        $image = $data['image'] ?? null;
+        $pickupOnly = !empty($data['pickup_only']) ? 1 : 0;
+        $productSku = $data['product_sku'] ?? null;
+        $quantity = isset($data['quantity']) ? max(1, (int) $data['quantity']) : 1;
+
+        if ($title === '' || $description === '' || $condition === '' || $price === '') {
+            return ['success' => false, 'error' => 'Missing required fields.'];
+        }
+
+        $status = $autoApprove ? 'approved' : 'pending';
+        $requiresReview = !$autoApprove;
+
+        $this->conn->begin_transaction();
+        try {
+            $stmt = $this->conn->prepare(
+                'INSERT INTO listings (owner_id, product_sku, title, description, `condition`, price, quantity, reserved_qty, category, tags, image, status, pickup_only) '
+                . 'VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?)'
+            );
+
+            if ($stmt === false) {
+                throw new RuntimeException('Unable to prepare listing creation.');
+            }
+
+            $stmt->bind_param(
+                'isssssisissi',
+                $ownerId,
+                $productSku,
+                $title,
+                $description,
+                $condition,
+                $price,
+                $quantity,
+                $category,
+                $tagsStorage,
+                $image,
+                $status,
+                $pickupOnly
+            );
+
+            if (!$stmt->execute()) {
+                $stmt->close();
+                throw new RuntimeException('Failed to save the listing.');
+            }
+
+            $listingId = (int) $stmt->insert_id;
+            $stmt->close();
+
+            if ($requiresReview) {
+                $this->changeRequests->createStatusRequest(
+                    $listingId,
+                    $ownerId,
+                    'approved',
+                    'Listing created and awaiting approval.'
+                );
+            }
+
+            $this->conn->commit();
+
+            shop_log('listing.created', [
+                'listing_id' => $listingId,
+                'owner_id' => $ownerId,
+                'status' => $status,
+            ]);
+
+            return [
+                'success' => true,
+                'listing_id' => $listingId,
+                'status' => $status,
+                'requires_review' => $requiresReview,
+            ];
+        } catch (Throwable $e) {
+            $this->conn->rollback();
+            shop_log('listing.create_error', [
+                'owner_id' => $ownerId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * Update stored tags for a listing.
+     *
+     * @return array{success: bool, changed: bool}
+     */
+    public function updateTags(int $listingId, int $actorId, array $tags): array
+    {
+        if ($listingId <= 0 || $actorId <= 0) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $listing = $this->fetchListing($listingId);
+        if (!$listing || (int) $listing['owner_id'] !== $actorId) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $storage = tags_to_storage($tags);
+        $sql = $storage === null
+            ? 'UPDATE listings SET tags = NULL, updated_at = NOW() WHERE id = ?'
+            : 'UPDATE listings SET tags = ?, updated_at = NOW() WHERE id = ?';
+
+        $stmt = $this->conn->prepare($sql);
+        if ($stmt === false) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        if ($storage === null) {
+            $stmt->bind_param('i', $listingId);
+        } else {
+            $stmt->bind_param('si', $storage, $listingId);
+        }
+
+        $success = $stmt->execute();
+        $changed = $success && $stmt->affected_rows > 0;
+        $stmt->close();
+
+        if ($changed) {
+            shop_log('listing.tags_updated', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+            ]);
+        }
+
+        return ['success' => $success, 'changed' => $changed];
+    }
+
+    /**
+     * Update the listing status, enforcing moderation when necessary.
+     *
+     * @return array{success: bool, changed: bool, status?: string, requires_review?: bool}
+     */
+    public function updateStatus(int $listingId, int $actorId, string $status, bool $isAdmin = false): array
+    {
+        $status = strtolower(trim($status));
+        if (!in_array($status, self::STATUSES, true)) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $listing = $this->fetchListing($listingId, true);
+        if (!$listing) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $ownerId = (int) $listing['owner_id'];
+        $currentStatus = (string) $listing['status'];
+        $isOwner = $ownerId === $actorId;
+
+        if (!$isOwner && !$isAdmin) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $allowed = $this->transitions[$currentStatus] ?? [];
+        if ($currentStatus === $status) {
+            return ['success' => true, 'changed' => false, 'status' => $currentStatus];
+        }
+
+        if (!in_array($status, $allowed, true)) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        if ($this->statusRequiresApproval($status) && !$isAdmin) {
+            $this->changeRequests->createStatusRequest(
+                $listingId,
+                $actorId,
+                $status,
+                'Seller requested status change.'
+            );
+
+            shop_log('listing.status_requested', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+                'target_status' => $status,
+            ]);
+
+            return ['success' => true, 'changed' => false, 'requires_review' => true];
+        }
+
+        $stmt = $this->conn->prepare('UPDATE listings SET status = ?, updated_at = NOW() WHERE id = ?');
+        if ($stmt === false) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $stmt->bind_param('si', $status, $listingId);
+        $success = $stmt->execute();
+        $changed = $success && $stmt->affected_rows > 0;
+        $stmt->close();
+
+        if ($success) {
+            $this->changeRequests->approveOpenRequests($listingId, $actorId, $status);
+            shop_log('listing.status_updated', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+                'status' => $status,
+                'changed' => $changed,
+            ]);
+        }
+
+        return ['success' => $success, 'changed' => $changed, 'status' => $status];
+    }
+
+    /**
+     * Delete a listing owned by the actor.
+     */
+    public function delete(int $listingId, int $actorId, bool $isAdmin = false): array
+    {
+        if ($listingId <= 0 || $actorId <= 0) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $listing = $this->fetchListing($listingId);
+        if (!$listing) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $ownerId = (int) $listing['owner_id'];
+        if ($ownerId !== $actorId && !$isAdmin) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $stmt = $this->conn->prepare('DELETE FROM listings WHERE id = ?');
+        if ($stmt === false) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $stmt->bind_param('i', $listingId);
+        $success = $stmt->execute();
+        $changed = $success && $stmt->affected_rows > 0;
+        $stmt->close();
+
+        if ($changed) {
+            $this->changeRequests->cancelOpenRequests($listingId, $ownerId);
+            shop_log('listing.deleted', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+                'is_admin' => $isAdmin,
+            ]);
+        }
+
+        return ['success' => $success, 'changed' => $changed];
+    }
+
+    /**
+     * Paginate listings for the owner.
+     *
+     * @return array{items: array<int, array<string, mixed>>, filters: array<string, mixed>, pagination: array<string, int>}
+     */
+    public function paginateForOwner(int $ownerId, array $filters = [], bool $withSyncState = false): array
+    {
+        $sanitizedStatus = $this->sanitizeStatus($filters['status'] ?? '');
+        $search = trim((string) ($filters['search'] ?? ''));
+        $perPage = max(1, min(50, (int) ($filters['per_page'] ?? 10)));
+        $page = max(1, (int) ($filters['page'] ?? 1));
+
+        $types = 'i';
+        $params = [$ownerId];
+        $where = 'WHERE l.owner_id = ?';
+
+        if ($sanitizedStatus !== '') {
+            $where .= ' AND l.status = ?';
+            $types .= 's';
+            $params[] = $sanitizedStatus;
+        }
+
+        if ($search !== '') {
+            $where .= ' AND l.title LIKE ?';
+            $types .= 's';
+            $params[] = '%' . $search . '%';
+        }
+
+        $countSql = 'SELECT COUNT(*) FROM listings l ' . $where;
+        $total = 0;
+        if ($stmt = $this->conn->prepare($countSql)) {
+            $stmt->bind_param($types, ...$params);
+            if ($stmt->execute()) {
+                $stmt->bind_result($totalCount);
+                if ($stmt->fetch()) {
+                    $total = (int) $totalCount;
+                }
+            }
+            $stmt->close();
+        }
+
+        $pages = max(1, (int) ceil($total / $perPage));
+        if ($page > $pages) {
+            $page = $pages;
+        }
+
+        $offset = ($page - 1) * $perPage;
+        $items = [];
+
+        $select = 'SELECT l.id, l.title, l.price, l.category, l.tags, l.image, l.status, l.pickup_only, l.created_at, '
+            . 'l.updated_at, l.quantity, l.reserved_qty';
+
+        if ($withSyncState) {
+            $select .= ', scm.sync_status AS square_sync_status, scm.square_object_id AS square_object_id';
+        }
+
+        $select .= ' FROM listings l';
+
+        if ($withSyncState) {
+            $select .= ' LEFT JOIN square_catalog_map scm ON scm.local_type = "listing" AND scm.local_id = l.id';
+        }
+
+        $select .= ' ' . $where . ' ORDER BY l.created_at DESC LIMIT ? OFFSET ?';
+
+        $listTypes = $types . 'ii';
+        $listParams = array_merge($params, [$perPage, $offset]);
+
+        if ($stmt = $this->conn->prepare($select)) {
+            $stmt->bind_param($listTypes, ...$listParams);
+            if ($stmt->execute()) {
+                $result = $stmt->get_result();
+                if ($result instanceof mysqli_result) {
+                    while ($row = $result->fetch_assoc()) {
+                        $items[] = [
+                            'id' => (int) $row['id'],
+                            'title' => (string) $row['title'],
+                            'price' => $row['price'],
+                            'category' => $row['category'],
+                            'tags' => tags_from_storage($row['tags'] ?? null),
+                            'status' => (string) $row['status'],
+                            'pickup_only' => (bool) $row['pickup_only'],
+                            'created_at' => $row['created_at'],
+                            'updated_at' => $row['updated_at'],
+                            'quantity' => isset($row['quantity']) ? (int) $row['quantity'] : null,
+                            'reserved_qty' => isset($row['reserved_qty']) ? (int) $row['reserved_qty'] : null,
+                            'image' => $row['image'],
+                            'square_sync_status' => $row['square_sync_status'] ?? null,
+                            'square_object_id' => $row['square_object_id'] ?? null,
+                        ];
+                    }
+                }
+            }
+            $stmt->close();
+        }
+
+        return [
+            'items' => $items,
+            'filters' => [
+                'status' => $sanitizedStatus,
+                'search' => $search,
+                'page' => $page,
+                'per_page' => $perPage,
+            ],
+            'pagination' => [
+                'page' => $page,
+                'per_page' => $perPage,
+                'total' => $total,
+                'pages' => $pages,
+            ],
+        ];
+    }
+
+    /**
+     * Fetch a single listing record.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function fetchListing(int $listingId, bool $forUpdate = false): ?array
+    {
+        if ($listingId <= 0) {
+            return null;
+        }
+
+        $sql = 'SELECT id, owner_id, status, quantity, reserved_qty, product_sku FROM listings WHERE id = ?';
+        if ($forUpdate) {
+            $sql .= ' FOR UPDATE';
+        }
+
+        $stmt = $this->conn->prepare($sql);
+        if ($stmt === false) {
+            return null;
+        }
+
+        $stmt->bind_param('i', $listingId);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            return null;
+        }
+
+        $result = $stmt->get_result();
+        $row = $result ? $result->fetch_assoc() : null;
+        $stmt->close();
+
+        return $row ?: null;
+    }
+
+    /**
+     * Expose permitted statuses for UIs.
+     *
+     * @return array<int, string>
+     */
+    public function allowedStatuses(): array
+    {
+        return self::STATUSES;
+    }
+
+    private function statusRequiresApproval(string $status): bool
+    {
+        return in_array($status, ['approved', 'live'], true);
+    }
+
+    private function sanitizeStatus($status): string
+    {
+        $status = strtolower(trim((string) $status));
+        return in_array($status, self::STATUSES, true) ? $status : '';
+    }
+}

--- a/includes/repositories/OrdersService.php
+++ b/includes/repositories/OrdersService.php
@@ -1,0 +1,227 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/ShopLogger.php';
+require_once __DIR__ . '/InventoryService.php';
+require_once __DIR__ . '/../orders.php';
+
+final class OrdersService
+{
+    private mysqli $conn;
+    private InventoryService $inventory;
+
+    public function __construct(mysqli $conn, ?InventoryService $inventory = null)
+    {
+        $this->conn = $conn;
+        $this->inventory = $inventory ?? new InventoryService($conn);
+    }
+
+    /**
+     * Create an order fulfillment record and capture the reserved inventory.
+     *
+     * @param array<string, mixed> $shipping
+     * @param array<string, mixed> $options
+     * @return array{order_id: int}
+     */
+    public function createFulfillment(
+        int $paymentId,
+        int $buyerId,
+        int $listingId,
+        array $shipping,
+        array $options = []
+    ): array {
+        $quantity = max(1, (int) ($options['quantity'] ?? 1));
+        $sku = isset($options['sku']) ? (string) $options['sku'] : null;
+        $isOfficialOrder = !empty($options['is_official_order']) ? 1 : 0;
+        $shippingProfileId = isset($options['shipping_profile_id']) ? (int) $options['shipping_profile_id'] : null;
+        $notes = isset($shipping['notes']) ? (string) $shipping['notes'] : '';
+        $address = isset($shipping['address']) ? (string) $shipping['address'] : '';
+        $deliveryMethod = isset($shipping['delivery_method']) ? (string) $shipping['delivery_method'] : '';
+        $snapshot = $shipping['snapshot'] ?? null;
+
+        $stmt = $this->conn->prepare(
+            'INSERT INTO order_fulfillments '
+            . '(payment_id, user_id, listing_id, sku, shipping_address, delivery_method, notes, tracking_number, status, shipping_profile_id, shipping_snapshot, is_official_order) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?, NULL, "pending", NULLIF(?, 0), ?, ?)'
+        );
+        if ($stmt === false) {
+            throw new RuntimeException('Unable to prepare order creation.');
+        }
+
+        $stmt->bind_param(
+            'iiissssisi',
+            $paymentId,
+            $buyerId,
+            $listingId,
+            $sku,
+            $address,
+            $deliveryMethod,
+            $notes,
+            $shippingProfileId,
+            $snapshot,
+            $isOfficialOrder
+        );
+
+        if (!$stmt->execute()) {
+            $stmt->close();
+            throw new RuntimeException('Failed to create order fulfillment.');
+        }
+
+        $orderId = (int) $stmt->insert_id;
+        $stmt->close();
+
+        $this->inventory->captureListing($listingId, $quantity, $buyerId, $orderId);
+
+        shop_log('order.created', [
+            'order_id' => $orderId,
+            'listing_id' => $listingId,
+            'buyer_id' => $buyerId,
+            'quantity' => $quantity,
+        ]);
+
+        return ['order_id' => $orderId];
+    }
+
+    /**
+     * Update an order fulfillment status with permission enforcement.
+     *
+     * @return array{order_id: int, status: string, status_label: string}
+     */
+    public function updateStatus(int $orderId, string $status, int $viewerId, bool $isAdmin, bool $isOfficial): array
+    {
+        $statusOptions = order_fulfillment_status_options();
+        if (!array_key_exists($status, $statusOptions)) {
+            throw new RuntimeException('Unsupported fulfillment status.');
+        }
+
+        $order = $isAdmin
+            ? fetch_order_detail_for_admin($this->conn, $orderId, $viewerId)
+            : fetch_order_detail_for_user($this->conn, $orderId, $viewerId);
+
+        if (!$order && $isOfficial) {
+            $order = fetch_order_detail_for_admin($this->conn, $orderId, $viewerId);
+        }
+
+        if (!$order) {
+            throw new RuntimeException('Order could not be found.');
+        }
+
+        if (!$this->canManageOrder($order, $viewerId, $isAdmin, $isOfficial)) {
+            throw new RuntimeException('You do not have permission to update this order.');
+        }
+
+        $stmt = $this->conn->prepare('UPDATE order_fulfillments SET status = ? WHERE id = ?');
+        if ($stmt === false) {
+            throw new RuntimeException('Unable to prepare order update.');
+        }
+
+        $stmt->bind_param('si', $status, $orderId);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            throw new RuntimeException('Failed to update the order status.');
+        }
+        $stmt->close();
+
+        shop_log('order.status_updated', [
+            'order_id' => $orderId,
+            'actor_id' => $viewerId,
+            'status' => $status,
+        ]);
+
+        return [
+            'order_id' => $orderId,
+            'status' => $status,
+            'status_label' => $statusOptions[$status],
+        ];
+    }
+
+    /**
+     * Update tracking information for a fulfillment.
+     *
+     * @return array{order_id: int, tracking_number: ?string}
+     */
+    public function updateTracking(int $orderId, ?string $tracking, int $viewerId, bool $isAdmin, bool $isOfficial): array
+    {
+        $tracking = $tracking !== null ? trim($tracking) : null;
+        if ($tracking === '') {
+            $tracking = null;
+        }
+
+        if ($tracking !== null && strlen($tracking) > 100) {
+            throw new RuntimeException('Tracking numbers must be 100 characters or fewer.');
+        }
+
+        $order = $isAdmin
+            ? fetch_order_detail_for_admin($this->conn, $orderId, $viewerId)
+            : fetch_order_detail_for_user($this->conn, $orderId, $viewerId);
+
+        if (!$order && $isOfficial) {
+            $order = fetch_order_detail_for_admin($this->conn, $orderId, $viewerId);
+        }
+
+        if (!$order) {
+            throw new RuntimeException('Order could not be found.');
+        }
+
+        if (!$this->canManageOrder($order, $viewerId, $isAdmin, $isOfficial)) {
+            throw new RuntimeException('You do not have permission to update tracking for this order.');
+        }
+
+        if ($tracking !== null) {
+            $stmt = $this->conn->prepare('UPDATE order_fulfillments SET tracking_number = ? WHERE id = ?');
+        } else {
+            $stmt = $this->conn->prepare('UPDATE order_fulfillments SET tracking_number = NULL WHERE id = ?');
+        }
+
+        if ($stmt === false) {
+            throw new RuntimeException('Unable to prepare tracking update.');
+        }
+
+        if ($tracking !== null) {
+            $stmt->bind_param('si', $tracking, $orderId);
+        } else {
+            $stmt->bind_param('i', $orderId);
+        }
+
+        if (!$stmt->execute()) {
+            $stmt->close();
+            throw new RuntimeException('Failed to update tracking details.');
+        }
+        $stmt->close();
+
+        shop_log('order.tracking_updated', [
+            'order_id' => $orderId,
+            'actor_id' => $viewerId,
+            'tracking' => $tracking,
+        ]);
+
+        return [
+            'order_id' => $orderId,
+            'tracking_number' => $tracking,
+        ];
+    }
+
+    /**
+     * Determine whether the viewer can manage the order.
+     *
+     * @param array<string, mixed> $order
+     */
+    private function canManageOrder(array $order, int $viewerId, bool $isAdmin, bool $isOfficial): bool
+    {
+        if ($isAdmin) {
+            return true;
+        }
+
+        if ($isOfficial && (
+            !empty($order['product']['is_skuze_official'])
+            || !empty($order['product']['is_skuze_product'])
+            || !empty($order['listing']['is_official'])
+            || !empty($order['is_official_order'])
+        )) {
+            return true;
+        }
+
+        $ownerId = (int) ($order['listing']['owner_id'] ?? 0);
+        return $ownerId === $viewerId;
+    }
+}

--- a/includes/repositories/ShopLogger.php
+++ b/includes/repositories/ShopLogger.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Write a structured event to the shop log for auditing.
+ */
+function shop_log(string $event, array $context = []): void
+{
+    $logDir = dirname(__DIR__, 1) . '/../logs';
+    $file = $logDir . '/shop.log';
+
+    if (!is_dir($logDir)) {
+        mkdir($logDir, 0775, true);
+    }
+
+    $timestamp = date('Y-m-d H:i:s');
+    $payload = $context ? json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : '';
+    if ($payload === false) {
+        $payload = '';
+    }
+
+    $line = sprintf('[%s] %s%s', $timestamp, $event, $payload !== '' ? ' ' . $payload : '');
+
+    file_put_contents($file, $line . PHP_EOL, FILE_APPEND | LOCK_EX);
+}

--- a/includes/repositories/SquareCatalogSync.php
+++ b/includes/repositories/SquareCatalogSync.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/ShopLogger.php';
+
+final class SquareCatalogSync
+{
+    private mysqli $conn;
+    private bool $enabled;
+
+    public function __construct(mysqli $conn, array $config)
+    {
+        $this->conn = $conn;
+        $this->enabled = !empty($config['SQUARE_CATALOG_SYNC']) && $this->tableExists();
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Queue a listing for synchronization with Square.
+     *
+     * @return array{success: bool, status: string, square_object_id: string}
+     */
+    public function queueListingSync(int $listingId, int $actorId): array
+    {
+        if (!$this->enabled) {
+            return ['success' => false, 'status' => 'disabled', 'square_object_id' => ''];
+        }
+
+        if ($listingId <= 0) {
+            return ['success' => false, 'status' => 'invalid', 'square_object_id' => ''];
+        }
+
+        $objectId = $this->lookupCurrentSquareId($listingId) ?? ('listing#' . $listingId);
+
+        $stmt = $this->conn->prepare(
+            'INSERT INTO square_catalog_map (local_type, local_id, square_object_id, sync_status, last_synced_at) '
+            . 'VALUES ("listing", ?, ?, "pending", NULL) '
+            . 'ON DUPLICATE KEY UPDATE square_object_id = VALUES(square_object_id), sync_status = "pending", updated_at = NOW(), last_synced_at = NULL'
+        );
+
+        if ($stmt === false) {
+            throw new RuntimeException('Unable to prepare Square sync.');
+        }
+
+        $stmt->bind_param('is', $listingId, $objectId);
+        if (!$stmt->execute()) {
+            $error = $stmt->error;
+            $stmt->close();
+            throw new RuntimeException('Failed to queue Square sync: ' . $error);
+        }
+        $stmt->close();
+
+        shop_log('square.sync_listing', [
+            'listing_id' => $listingId,
+            'actor_id' => $actorId,
+            'square_object_id' => $objectId,
+        ]);
+
+        return ['success' => true, 'status' => 'pending', 'square_object_id' => $objectId];
+    }
+
+    /**
+     * Fetch sync state for a set of listings.
+     *
+     * @param array<int> $listingIds
+     * @return array<int, array{square_object_id: string|null, sync_status: string|null}>
+     */
+    public function listingSyncState(array $listingIds): array
+    {
+        if (!$this->enabled || !$listingIds) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($listingIds), '?'));
+        $types = str_repeat('i', count($listingIds));
+
+        $sql = 'SELECT local_id, square_object_id, sync_status FROM square_catalog_map '
+             . 'WHERE local_type = "listing" AND local_id IN (' . $placeholders . ')';
+
+        $stmt = $this->conn->prepare($sql);
+        if ($stmt === false) {
+            return [];
+        }
+
+        $stmt->bind_param($types, ...$listingIds);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            return [];
+        }
+
+        $result = $stmt->get_result();
+        $state = [];
+        if ($result) {
+            while ($row = $result->fetch_assoc()) {
+                $state[(int) $row['local_id']] = [
+                    'square_object_id' => $row['square_object_id'],
+                    'sync_status' => $row['sync_status'],
+                ];
+            }
+        }
+        $stmt->close();
+
+        return $state;
+    }
+
+    private function lookupCurrentSquareId(int $listingId): ?string
+    {
+        $stmt = $this->conn->prepare('SELECT square_object_id FROM square_catalog_map WHERE local_type = "listing" AND local_id = ? LIMIT 1');
+        if ($stmt === false) {
+            return null;
+        }
+
+        $stmt->bind_param('i', $listingId);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            return null;
+        }
+
+        $stmt->bind_result($objectId);
+        $hasRow = $stmt->fetch();
+        $stmt->close();
+
+        return $hasRow ? (string) $objectId : null;
+    }
+
+    private function tableExists(): bool
+    {
+        $result = $this->conn->query("SHOW TABLES LIKE 'square_catalog_map'");
+        if ($result instanceof mysqli_result) {
+            $exists = $result->num_rows > 0;
+            $result->free();
+            return $exists;
+        }
+
+        return false;
+    }
+}

--- a/includes/shop_manager.php
+++ b/includes/shop_manager.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/store.php';
+
+const SHOP_MANAGER_DEFAULT_TAB = 'listings';
+const SHOP_MANAGER_TABS = [
+    'listings' => [
+        'label' => 'Listings',
+        'description' => 'Review and manage your live, draft, or pending listings.',
+    ],
+    'inventory' => [
+        'label' => 'Inventory',
+        'description' => 'Track product stock levels and reorder points.',
+    ],
+    'orders' => [
+        'label' => 'Orders',
+        'description' => 'Monitor order flow and review purchase history.',
+    ],
+    'shipping' => [
+        'label' => 'Shipping',
+        'description' => 'Update fulfillment statuses and tracking numbers.',
+    ],
+    'settings' => [
+        'label' => 'Settings',
+        'description' => 'Configure default preferences for your shop.',
+    ],
+];
+
+/**
+ * Resolve the requested tab to a known value.
+ */
+function shop_manager_resolve_tab(?string $requested): string
+{
+    $requested = strtolower(trim((string) $requested));
+    if ($requested !== '' && array_key_exists($requested, SHOP_MANAGER_TABS)) {
+        return $requested;
+    }
+
+    return SHOP_MANAGER_DEFAULT_TAB;
+}
+
+/**
+ * Return the registered tab definitions.
+ *
+ * @return array<string, array{label: string, description: string}>
+ */
+function shop_manager_tabs(): array
+{
+    return SHOP_MANAGER_TABS;
+}
+
+/**
+ * Fetch a flash message payload for a specific tab.
+ *
+ * @return array{type: string, message: string}|null
+ */
+function shop_manager_consume_flash(string $tab): ?array
+{
+    if (!isset($_SESSION['shop_manager_flash']) || !is_array($_SESSION['shop_manager_flash'])) {
+        return null;
+    }
+
+    $payload = $_SESSION['shop_manager_flash'][$tab] ?? null;
+    if ($payload !== null) {
+        unset($_SESSION['shop_manager_flash'][$tab]);
+    }
+
+    if (!is_array($payload) || !isset($payload['type'], $payload['message'])) {
+        return null;
+    }
+
+    return [
+        'type' => (string) $payload['type'],
+        'message' => (string) $payload['message'],
+    ];
+}
+
+/**
+ * Queue a flash message for the requested tab.
+ */
+function shop_manager_flash(string $tab, string $type, string $message): void
+{
+    if (!isset($_SESSION['shop_manager_flash']) || !is_array($_SESSION['shop_manager_flash'])) {
+        $_SESSION['shop_manager_flash'] = [];
+    }
+
+    $_SESSION['shop_manager_flash'][$tab] = [
+        'type' => $type,
+        'message' => $message,
+    ];
+}

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -10,6 +10,7 @@
       <li><a href="trade-listings.php">Trade Listings</a></li>
       <li><a href="trade-listing.php">Create Listing</a></li>
       <li><a href="promoted.php">Promoted Shops</a></li>
+      <li><a href="shop-manager/index.php">Shop Manager</a></li>
       <li><a href="vip.php">VIP Plans</a></li>
     </ul>
   </div>

--- a/migrations/037_update_listings_and_products.sql
+++ b/migrations/037_update_listings_and_products.sql
@@ -1,0 +1,24 @@
+-- Normalize legacy listing statuses before updating the enum definition
+UPDATE listings
+   SET status = 'delisted'
+ WHERE status = 'rejected';
+
+-- Extend listings with new lifecycle statuses and inventory fields
+ALTER TABLE listings
+    MODIFY COLUMN status ENUM('draft','pending','approved','live','closed','delisted') NOT NULL DEFAULT 'draft',
+    ADD COLUMN IF NOT EXISTS quantity INT UNSIGNED NOT NULL DEFAULT 1 AFTER price,
+    ADD COLUMN IF NOT EXISTS reserved_qty INT UNSIGNED NOT NULL DEFAULT 0 AFTER quantity,
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER created_at;
+
+-- Ensure stored quantities remain in a valid range
+UPDATE listings
+   SET quantity = GREATEST(quantity, 1)
+ WHERE quantity < 1;
+
+UPDATE listings
+   SET reserved_qty = LEAST(reserved_qty, quantity)
+ WHERE reserved_qty > quantity;
+
+-- Add the missing audit columns to products
+ALTER TABLE products
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER created_at;

--- a/migrations/038_create_listing_and_inventory_tables.sql
+++ b/migrations/038_create_listing_and_inventory_tables.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS listing_change_requests (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    listing_id INT NOT NULL,
+    requester_id INT NOT NULL,
+    reviewer_id INT DEFAULT NULL,
+    change_type VARCHAR(32) NOT NULL DEFAULT 'status',
+    change_summary TEXT DEFAULT NULL,
+    requested_status ENUM('draft','pending','approved','live','closed','delisted') DEFAULT NULL,
+    payload JSON DEFAULT NULL,
+    status ENUM('pending','approved','rejected','cancelled') NOT NULL DEFAULT 'pending',
+    review_notes TEXT DEFAULT NULL,
+    resolved_at TIMESTAMP NULL DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_lcr_listing FOREIGN KEY (listing_id) REFERENCES listings(id) ON DELETE CASCADE,
+    CONSTRAINT fk_lcr_requester FOREIGN KEY (requester_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_lcr_reviewer FOREIGN KEY (reviewer_id) REFERENCES users(id) ON DELETE SET NULL,
+    INDEX idx_lcr_listing_status (listing_id, status),
+    INDEX idx_lcr_requester (requester_id),
+    INDEX idx_lcr_reviewer (reviewer_id)
+);
+
+CREATE TABLE IF NOT EXISTS inventory_transactions (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    product_sku VARCHAR(64) NOT NULL,
+    owner_id INT NOT NULL,
+    transaction_type VARCHAR(32) NOT NULL,
+    quantity_change INT NOT NULL,
+    quantity_before INT DEFAULT NULL,
+    quantity_after INT DEFAULT NULL,
+    reference_type VARCHAR(32) DEFAULT NULL,
+    reference_id BIGINT DEFAULT NULL,
+    metadata JSON DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_inventory_tx_product FOREIGN KEY (product_sku) REFERENCES products(sku) ON DELETE CASCADE,
+    CONSTRAINT fk_inventory_tx_owner FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_inventory_tx_product (product_sku),
+    INDEX idx_inventory_tx_owner (owner_id),
+    INDEX idx_inventory_tx_reference (reference_type, reference_id)
+);
+
+-- Optional Square catalog integration guard. Set @feature_square_catalog_map = 0 before
+-- running the migration to skip creating this table.
+SET @feature_square_catalog_map = COALESCE(@feature_square_catalog_map, 1);
+
+SET @square_catalog_map_sql = IF(
+    @feature_square_catalog_map = 1,
+    'CREATE TABLE IF NOT EXISTS square_catalog_map (
+        id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+        local_type ENUM(''product'',''listing'') NOT NULL,
+        local_id INT NOT NULL,
+        square_object_id VARCHAR(255) NOT NULL,
+        square_catalog_version BIGINT DEFAULT NULL,
+        sync_status ENUM(''pending'',''synced'',''failed'') NOT NULL DEFAULT ''pending'',
+        last_synced_at TIMESTAMP NULL DEFAULT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        UNIQUE KEY uniq_square_catalog_map_local (local_type, local_id),
+        UNIQUE KEY uniq_square_catalog_map_square (square_object_id),
+        KEY idx_square_catalog_map_sync_status (sync_status)
+    )',
+    'SELECT 1'
+);
+
+PREPARE create_square_catalog_map FROM @square_catalog_map_sql;
+EXECUTE create_square_catalog_map;
+DEALLOCATE PREPARE create_square_catalog_map;

--- a/my-listings.php
+++ b/my-listings.php
@@ -1,113 +1,12 @@
 <?php
 require_once __DIR__ . '/includes/auth.php';
-require 'includes/db.php';
-require 'includes/csrf.php';
-require 'includes/tags.php';
+require_once __DIR__ . '/includes/authz.php';
 
-$user_id = $_SESSION['user_id'];
+ensure_seller();
 
-$message = '';
-$error = '';
+$tab = isset($_GET['tab']) ? (string) $_GET['tab'] : 'listings';
+$allowed = ['listings', 'inventory', 'orders', 'shipping', 'settings'];
+$targetTab = in_array(strtolower($tab), $allowed, true) ? strtolower($tab) : 'listings';
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-  if (!validate_token($_POST['csrf_token'] ?? '')) {
-    $error = 'Invalid request token.';
-  } else {
-    $listing_id = (int)($_POST['listing_id'] ?? 0);
-    $tags_input = trim($_POST['tags'] ?? '');
-    $tags = tags_from_input($tags_input);
-    $tags_storage = tags_to_storage($tags);
-    if ($listing_id > 0) {
-      if ($stmt = $conn->prepare("UPDATE listings SET tags=? WHERE id=? AND owner_id=?")) {
-        $stmt->bind_param('sii', $tags_storage, $listing_id, $user_id);
-        if ($stmt->execute()) {
-          if ($stmt->affected_rows > 0) {
-            $message = 'Tags updated.';
-          } else {
-            $message = 'No changes were made.';
-          }
-        } else {
-          $error = 'Failed to update tags.';
-        }
-        $stmt->close();
-      } else {
-        $error = 'Failed to prepare tag update.';
-      }
-    }
-  }
-}
-
-// Handle deletion
-if (isset($_GET['delete'])) {
-  $id = intval($_GET['delete']);
-  $stmt = $conn->prepare("DELETE FROM listings WHERE id = ? AND owner_id = ?");
-  if ($stmt) {
-    $stmt->bind_param('ii', $id, $user_id);
-    $stmt->execute();
-    $stmt->close();
-  }
-  header('Location: my-listings.php');
-  exit;
-}
-
-$stmt = $conn->prepare("SELECT id, title, price, category, tags, image, status, pickup_only, created_at FROM listings WHERE owner_id = ? ORDER BY created_at DESC");
-$stmt->bind_param('i', $user_id);
-$stmt->execute();
-$listings = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
-$stmt->close();
-?>
-<?php require 'includes/layout.php'; ?>
-  <title>My Listings</title>
-  <link rel="stylesheet" href="assets/style.css">
-  <script src="assets/tags.js" defer></script>
-</head>
-<body>
-  <?php include 'includes/sidebar.php'; ?>
-  <?php include 'includes/header.php'; ?>
-  <h2>My Listings</h2>
-  <?php if ($message): ?>
-    <p class="notice"><?= htmlspecialchars($message); ?></p>
-  <?php endif; ?>
-  <?php if ($error): ?>
-    <p class="error"><?= htmlspecialchars($error); ?></p>
-  <?php endif; ?>
-  <p><a href="sell.php">Create a new listing</a></p>
-  <table class="table-listings">
-    <tr><th>Title</th><th>Price</th><th>Category</th><th>Tags</th><th>Image</th><th>Status</th><th>Pickup Only</th><th>Actions</th></tr>
-    <?php foreach ($listings as $l): ?>
-      <?php $tagValues = tags_from_storage($l['tags']); ?>
-      <tr>
-        <td><?= htmlspecialchars($l['title']) ?></td>
-        <td><?= htmlspecialchars($l['price']) ?></td>
-        <td><?= htmlspecialchars($l['category']) ?></td>
-        <td class="listing-tags">
-          <div class="tag-badges">
-            <?php if ($tagValues): ?>
-              <?php foreach ($tagValues as $tag): ?>
-                <span class="tag-chip tag-chip-static"><?= htmlspecialchars($tag) ?></span>
-              <?php endforeach; ?>
-            <?php else: ?>
-              <span class="tag-empty">No tags</span>
-            <?php endif; ?>
-          </div>
-          <form method="post" class="tag-edit-form">
-            <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
-            <input type="hidden" name="listing_id" value="<?= $l['id']; ?>">
-            <div class="tag-input" data-tag-editor>
-              <div class="tag-list" data-tag-list></div>
-              <input type="text" data-tag-source placeholder="Add tag">
-              <input type="hidden" name="tags" value="<?= htmlspecialchars(tags_to_input_value($tagValues)); ?>" data-tag-store>
-            </div>
-            <button type="submit" class="btn-secondary">Save Tags</button>
-          </form>
-        </td>
-        <td><?php if ($l['image']): ?><img class="thumb-square" style="--thumb-size:60px;" src="uploads/<?= htmlspecialchars($l['image']) ?>" alt=""><?php endif; ?></td>
-        <td><?= htmlspecialchars($l['status']) ?></td>
-        <td><?= $l['pickup_only'] ? 'Yes' : 'No' ?></td>
-        <td><a href="?delete=<?= $l['id'] ?>" onclick="return confirm('Delete listing?');">Delete</a></td>
-      </tr>
-    <?php endforeach; ?>
-  </table>
-  <?php include 'includes/footer.php'; ?>
-</body>
-</html>
+header('Location: /shop-manager/index.php?tab=' . urlencode($targetTab));
+exit;

--- a/schema/inventory_transactions.sql
+++ b/schema/inventory_transactions.sql
@@ -1,0 +1,20 @@
+-- SQL schema reference for inventory transactions
+CREATE TABLE inventory_transactions (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    product_sku VARCHAR(64) NOT NULL,
+    owner_id INT NOT NULL,
+    transaction_type VARCHAR(32) NOT NULL,
+    quantity_change INT NOT NULL,
+    quantity_before INT DEFAULT NULL,
+    quantity_after INT DEFAULT NULL,
+    reference_type VARCHAR(32) DEFAULT NULL,
+    reference_id BIGINT DEFAULT NULL,
+    metadata JSON DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (product_sku) REFERENCES products(sku) ON DELETE CASCADE,
+    FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_inventory_transactions_product ON inventory_transactions (product_sku);
+CREATE INDEX idx_inventory_transactions_owner ON inventory_transactions (owner_id);
+CREATE INDEX idx_inventory_transactions_reference ON inventory_transactions (reference_type, reference_id);

--- a/schema/listing_change_requests.sql
+++ b/schema/listing_change_requests.sql
@@ -1,0 +1,23 @@
+-- SQL schema reference for listing change requests
+CREATE TABLE listing_change_requests (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    listing_id INT NOT NULL,
+    requester_id INT NOT NULL,
+    reviewer_id INT DEFAULT NULL,
+    change_type VARCHAR(32) NOT NULL DEFAULT 'status',
+    change_summary TEXT DEFAULT NULL,
+    requested_status ENUM('draft','pending','approved','live','closed','delisted') DEFAULT NULL,
+    payload JSON DEFAULT NULL,
+    status ENUM('pending','approved','rejected','cancelled') NOT NULL DEFAULT 'pending',
+    review_notes TEXT DEFAULT NULL,
+    resolved_at TIMESTAMP NULL DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (listing_id) REFERENCES listings(id) ON DELETE CASCADE,
+    FOREIGN KEY (requester_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (reviewer_id) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_listing_change_requests_listing_status ON listing_change_requests (listing_id, status);
+CREATE INDEX idx_listing_change_requests_requester ON listing_change_requests (requester_id);
+CREATE INDEX idx_listing_change_requests_reviewer ON listing_change_requests (reviewer_id);

--- a/schema/listings.sql
+++ b/schema/listings.sql
@@ -1,0 +1,26 @@
+-- SQL schema reference for listings
+CREATE TABLE listings (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    owner_id INT NOT NULL,
+    product_sku VARCHAR(64) DEFAULT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    `condition` VARCHAR(50) NOT NULL,
+    price DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+    quantity INT UNSIGNED NOT NULL DEFAULT 1,
+    reserved_qty INT UNSIGNED NOT NULL DEFAULT 0,
+    category VARCHAR(50),
+    tags TEXT DEFAULT NULL,
+    image VARCHAR(255) NOT NULL,
+    status ENUM('draft','pending','approved','live','closed','delisted') NOT NULL DEFAULT 'draft',
+    is_official_listing TINYINT(1) NOT NULL DEFAULT 0,
+    pickup_only TINYINT(1) NOT NULL DEFAULT 0,
+    sale_price DECIMAL(10,2) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (product_sku) REFERENCES products(sku)
+);
+
+CREATE INDEX idx_listings_product_sku ON listings (product_sku);
+CREATE INDEX idx_listings_tags ON listings (tags(191));

--- a/schema/products.sql
+++ b/schema/products.sql
@@ -4,10 +4,15 @@ CREATE TABLE products (
     title VARCHAR(255) NOT NULL,
     description TEXT,
     quantity INT NOT NULL DEFAULT 0,
-    reorder_threshold INT NOT NULL DEFAULT 0,
-    is_official TINYINT(1) NOT NULL DEFAULT 0,
+    stock INT NOT NULL DEFAULT 0,
+    reserved TINYINT(1) NOT NULL DEFAULT 0,
     owner_id INT NOT NULL,
     price DECIMAL(10,2) NOT NULL DEFAULT 0.00,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    reorder_threshold INT NOT NULL DEFAULT 0,
+    is_official TINYINT(1) NOT NULL DEFAULT 0,
+    is_skuze_official TINYINT(1) NOT NULL DEFAULT 0,
+    is_skuze_product TINYINT(1) NOT NULL DEFAULT 0,
     FOREIGN KEY (owner_id) REFERENCES users(id)
 );

--- a/schema/square_catalog_map.sql
+++ b/schema/square_catalog_map.sql
@@ -1,0 +1,16 @@
+-- SQL schema reference for the optional Square catalog map
+CREATE TABLE square_catalog_map (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    local_type ENUM('product','listing') NOT NULL,
+    local_id INT NOT NULL,
+    square_object_id VARCHAR(255) NOT NULL,
+    square_catalog_version BIGINT DEFAULT NULL,
+    sync_status ENUM('pending','synced','failed') NOT NULL DEFAULT 'pending',
+    last_synced_at TIMESTAMP NULL DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX uniq_square_catalog_map_local ON square_catalog_map (local_type, local_id);
+CREATE UNIQUE INDEX uniq_square_catalog_map_square ON square_catalog_map (square_object_id);
+CREATE INDEX idx_square_catalog_map_sync_status ON square_catalog_map (sync_status);

--- a/shop-manager/index.php
+++ b/shop-manager/index.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/authz.php';
+require_once __DIR__ . '/../includes/csrf.php';
+require_once __DIR__ . '/../includes/shop_manager.php';
+require_once __DIR__ . '/../includes/tags.php';
+require_once __DIR__ . '/../includes/repositories/ChangeRequestsService.php';
+require_once __DIR__ . '/../includes/repositories/ListingsRepo.php';
+require_once __DIR__ . '/../includes/repositories/SquareCatalogSync.php';
+
+$config = require __DIR__ . '/../config.php';
+
+ensure_seller();
+
+$viewerId = (int) ($_SESSION['user_id'] ?? 0);
+/** @var mysqli $conn */
+if (isset($conn) && $conn instanceof mysqli) {
+    $db = $conn;
+} else {
+    $db = require __DIR__ . '/../includes/db.php';
+}
+
+$changeRequests = new ChangeRequestsService($db);
+$listingsRepository = new ListingsRepo($db, $changeRequests);
+$squareSync = new SquareCatalogSync($db, $config);
+$squareSyncEnabled = $squareSync->isEnabled();
+$isAdmin = authz_has_role('admin');
+
+$requestedTab = $_SERVER['REQUEST_METHOD'] === 'POST'
+    ? ($_POST['tab'] ?? SHOP_MANAGER_DEFAULT_TAB)
+    : ($_GET['tab'] ?? SHOP_MANAGER_DEFAULT_TAB);
+$activeTab = shop_manager_resolve_tab($requestedTab);
+$tabs = shop_manager_tabs();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $token = $_POST['csrf_token'] ?? '';
+    if (!validate_token($token)) {
+        shop_manager_flash($activeTab, 'error', 'Invalid request token. Please try again.');
+    } else {
+        $action = $_POST['manager_action'] ?? '';
+        $redirectTab = shop_manager_resolve_tab($_POST['tab'] ?? $activeTab);
+
+        switch ($action) {
+            case 'update_listing_tags':
+                $listingId = (int) ($_POST['listing_id'] ?? 0);
+                $tagsInput = trim((string) ($_POST['tags'] ?? ''));
+                $tags = tags_from_input($tagsInput);
+                $result = $listingsRepository->updateTags($listingId, $viewerId, $tags);
+                if (!$result['success']) {
+                    shop_manager_flash($redirectTab, 'error', 'Unable to update listing tags.');
+                } else {
+                    $message = $result['changed'] ? 'Listing tags updated.' : 'No changes were required.';
+                    shop_manager_flash($redirectTab, 'success', $message);
+                }
+                break;
+            case 'update_listing_status':
+                $listingId = (int) ($_POST['listing_id'] ?? 0);
+                $status = (string) ($_POST['status'] ?? '');
+                $result = $listingsRepository->updateStatus($listingId, $viewerId, $status, $isAdmin);
+                if (!$result['success']) {
+                    shop_manager_flash($redirectTab, 'error', 'Unable to update listing status.');
+                } else {
+                    if (!empty($result['requires_review'])) {
+                        $message = 'Status change submitted for review.';
+                    } else {
+                        $message = $result['changed'] ? 'Listing status updated.' : 'Status is unchanged.';
+                    }
+                    shop_manager_flash($redirectTab, 'success', $message);
+                }
+                break;
+            case 'delete_listing':
+                $listingId = (int) ($_POST['listing_id'] ?? 0);
+                $result = $listingsRepository->delete($listingId, $viewerId, $isAdmin);
+                if (!$result['success']) {
+                    shop_manager_flash($redirectTab, 'error', 'Unable to delete the listing.');
+                } else {
+                    $message = $result['changed'] ? 'Listing deleted.' : 'Listing was not found or already removed.';
+                    shop_manager_flash($redirectTab, 'success', $message);
+                }
+                break;
+            case 'sync_listing':
+                $listingId = (int) ($_POST['listing_id'] ?? 0);
+                if (!$squareSyncEnabled) {
+                    shop_manager_flash($redirectTab, 'error', 'Square sync is disabled.');
+                    break;
+                }
+
+                $listing = $listingsRepository->fetchListing($listingId);
+                if (!$listing || ((int) $listing['owner_id'] !== $viewerId && !$isAdmin)) {
+                    shop_manager_flash($redirectTab, 'error', 'Listing could not be found.');
+                    break;
+                }
+
+                try {
+                    $squareSync->queueListingSync($listingId, $viewerId);
+                    shop_manager_flash($redirectTab, 'success', 'Listing queued for Square sync.');
+                } catch (Throwable $e) {
+                    shop_manager_flash($redirectTab, 'error', 'Unable to queue Square sync.');
+                }
+                break;
+            default:
+                shop_manager_flash($redirectTab, 'error', 'Unsupported manager action.');
+        }
+    }
+
+    $query = ['tab' => $activeTab];
+    if (!empty($_POST['filters']) && is_array($_POST['filters'])) {
+        foreach ($_POST['filters'] as $key => $value) {
+            if ($value === '' || $value === null) {
+                continue;
+            }
+            $query[$key] = is_string($value) ? $value : (string) $value;
+        }
+    }
+
+    $redirectUrl = '/shop-manager/index.php';
+    if ($query) {
+        $redirectUrl .= '?' . http_build_query($query);
+    }
+
+    header('Location: ' . $redirectUrl);
+    exit;
+}
+
+$listingsFilters = [
+    'status' => $_GET['status'] ?? '',
+    'search' => $_GET['search'] ?? '',
+    'page' => isset($_GET['page']) ? (int) $_GET['page'] : 1,
+    'per_page' => isset($_GET['per_page']) ? (int) $_GET['per_page'] : 10,
+];
+$listingsData = $listingsRepository->paginateForOwner($viewerId, $listingsFilters, $squareSyncEnabled);
+$listingsStatuses = $listingsRepository->allowedStatuses();
+
+$storeInventory = store_fetch_inventory($db, $viewerId, STORE_SCOPE_MINE);
+$isOfficial = store_user_is_official($db, $viewerId);
+$ordersList = store_fetch_orders($db, $viewerId, STORE_SCOPE_MINE, $isAdmin, $isOfficial);
+$shippingList = store_manageable_shipping_orders($ordersList, $viewerId, $isAdmin, $isOfficial);
+$fulfillmentStatusOptions = order_fulfillment_status_options();
+
+$csrfToken = generate_token();
+$flash = shop_manager_consume_flash($activeTab);
+?>
+<?php require __DIR__ . '/../includes/layout.php'; ?>
+  <title>Shop Manager</title>
+  <link rel="stylesheet" href="/assets/style.css">
+  <script src="/assets/tags.js" defer></script>
+  <script type="module" src="/assets/store.js" defer></script>
+  <script type="module" src="/assets/shop-manager.js" defer></script>
+</head>
+<body>
+  <?php include __DIR__ . '/../includes/sidebar.php'; ?>
+  <?php include __DIR__ . '/../includes/header.php'; ?>
+  <div
+    class="page-container store shop-manager"
+    data-shop-manager
+    data-active-tab="<?= htmlspecialchars($activeTab, ENT_QUOTES, 'UTF-8'); ?>"
+    data-csrf="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>"
+  >
+    <header class="store__header">
+      <div>
+        <h2>Shop Manager</h2>
+        <p class="store__subtitle">A single workspace for listings, inventory, and fulfillment tasks.</p>
+      </div>
+    </header>
+
+    <div class="store__tabs" role="tablist" aria-label="Shop manager sections">
+      <?php foreach ($tabs as $tabKey => $tabMeta): ?>
+        <?php
+          $isActive = $tabKey === $activeTab;
+          $buttonId = 'shop-manager-tab-' . $tabKey;
+          $panelId = 'shop-manager-panel-' . $tabKey;
+        ?>
+        <button
+          type="button"
+          id="<?= htmlspecialchars($buttonId, ENT_QUOTES, 'UTF-8'); ?>"
+          class="store__tab<?= $isActive ? ' is-active' : ''; ?>"
+          role="tab"
+          aria-controls="<?= htmlspecialchars($panelId, ENT_QUOTES, 'UTF-8'); ?>"
+          aria-selected="<?= $isActive ? 'true' : 'false'; ?>"
+          data-manager-tab="<?= htmlspecialchars($tabKey, ENT_QUOTES, 'UTF-8'); ?>"
+        >
+          <?= htmlspecialchars($tabMeta['label'], ENT_QUOTES, 'UTF-8'); ?>
+        </button>
+      <?php endforeach; ?>
+    </div>
+
+    <div class="store__alert<?= $flash && $flash['type'] === 'error' ? ' is-error' : ''; ?>" role="status" aria-live="polite" data-manager-alert>
+      <?= $flash ? htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8') : ''; ?>
+    </div>
+
+    <?php
+      $listingsItems = $listingsData['items'];
+      $listingsFilterState = $listingsData['filters'];
+      $listingsPagination = $listingsData['pagination'];
+      $orders = $ordersList;
+      $shipping = $shippingList;
+      $squareSyncAvailable = $squareSyncEnabled;
+      include __DIR__ . '/listings.php';
+      include __DIR__ . '/inventory.php';
+      include __DIR__ . '/orders.php';
+      include __DIR__ . '/shipping.php';
+      include __DIR__ . '/settings.php';
+    ?>
+  </div>
+  <?php include __DIR__ . '/../includes/footer.php'; ?>
+</body>
+</html>

--- a/shop-manager/inventory.php
+++ b/shop-manager/inventory.php
@@ -1,0 +1,78 @@
+<?php
+$inventoryActive = $activeTab === 'inventory';
+$inventoryPanelId = 'shop-manager-panel-inventory';
+$inventoryTabId = 'shop-manager-tab-inventory';
+?>
+<section
+  id="<?= htmlspecialchars($inventoryPanelId, ENT_QUOTES, 'UTF-8'); ?>"
+  class="store__panel<?= $inventoryActive ? ' is-active' : ''; ?>"
+  role="tabpanel"
+  aria-labelledby="<?= htmlspecialchars($inventoryTabId, ENT_QUOTES, 'UTF-8'); ?>"
+  data-manager-panel="inventory"
+  data-repository="inventory"
+  <?= $inventoryActive ? '' : 'hidden'; ?>
+>
+  <header class="manager-panel__header">
+    <div>
+      <h3 class="manager-panel__title">Inventory</h3>
+      <p class="manager-panel__description">Review SKUs, adjust stock counts, and manage reorder thresholds.</p>
+    </div>
+  </header>
+
+  <?php if ($storeInventory): ?>
+  <div class="table-wrapper">
+    <table class="store-table" data-manager-controller="inventory">
+      <thead>
+        <tr>
+          <th scope="col">SKU</th>
+          <th scope="col">Product</th>
+          <th scope="col">Stock</th>
+          <th scope="col">Reorder point</th>
+          <th scope="col" class="store-table__actions">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($storeInventory as $item): ?>
+        <tr class="store-inventory" data-sku="<?= htmlspecialchars($item['sku'], ENT_QUOTES, 'UTF-8'); ?>">
+          <th scope="row"><?= htmlspecialchars($item['sku'], ENT_QUOTES, 'UTF-8'); ?></th>
+          <td>
+            <?= htmlspecialchars($item['title'], ENT_QUOTES, 'UTF-8'); ?>
+            <?php if (!empty($item['is_skuze_official'])): ?>
+              <span class="badge badge-official">SkuzE Official</span>
+            <?php endif; ?>
+            <?php if (!empty($item['is_skuze_product'])): ?>
+              <span class="badge badge-product">SkuzE Product</span>
+            <?php endif; ?>
+          </td>
+          <td class="store-inventory__quantity" data-field="stock"><?= (int) $item['stock']; ?></td>
+          <td class="store-inventory__threshold" data-field="reorder_threshold"><?= (int) $item['reorder_threshold']; ?></td>
+          <td class="store-inventory__actions">
+            <button type="button" class="store-inventory__edit" data-action="edit">Adjust stock</button>
+            <form class="store-inventory__form" method="post" action="/account/store_inventory_update.php" hidden>
+              <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+              <input type="hidden" name="sku" value="<?= htmlspecialchars($item['sku'], ENT_QUOTES, 'UTF-8'); ?>">
+              <div class="store-inventory__field">
+                <label>Adjust stock
+                  <input type="number" name="stock_delta" value="0" step="1">
+                </label>
+              </div>
+              <div class="store-inventory__field">
+                <label>Reorder threshold
+                  <input type="number" name="reorder_threshold" value="<?= (int) $item['reorder_threshold']; ?>" min="0" step="1">
+                </label>
+              </div>
+              <div class="store-inventory__buttons">
+                <button type="submit" class="btn">Save</button>
+                <button type="button" class="btn btn-secondary" data-action="cancel">Cancel</button>
+              </div>
+            </form>
+          </td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <?php else: ?>
+    <p class="notice">No inventory items are associated with your shop yet.</p>
+  <?php endif; ?>
+</section>

--- a/shop-manager/listings.php
+++ b/shop-manager/listings.php
@@ -1,0 +1,204 @@
+<?php
+$listingsActive = $activeTab === 'listings';
+$listingsPanelId = 'shop-manager-panel-listings';
+$listingsTabId = 'shop-manager-tab-listings';
+$listingsStatus = $listingsFilterState['status'] ?? '';
+$listingsSearch = $listingsFilterState['search'] ?? '';
+$listingsPerPage = (int) ($listingsFilterState['per_page'] ?? 10);
+$listingsPage = (int) ($listingsFilterState['page'] ?? 1);
+$listingsPageCount = (int) ($listingsPagination['pages'] ?? 1);
+$listingsTotal = (int) ($listingsPagination['total'] ?? count($listingsItems));
+$squareSyncAvailable = !empty($squareSyncAvailable);
+$paginationQuery = [
+    'tab' => 'listings',
+    'status' => $listingsStatus,
+    'search' => $listingsSearch,
+    'per_page' => $listingsPerPage,
+];
+?>
+<section
+  id="<?= htmlspecialchars($listingsPanelId, ENT_QUOTES, 'UTF-8'); ?>"
+  class="store__panel<?= $listingsActive ? ' is-active' : ''; ?>"
+  role="tabpanel"
+  aria-labelledby="<?= htmlspecialchars($listingsTabId, ENT_QUOTES, 'UTF-8'); ?>"
+  data-manager-panel="listings"
+  data-repository="listings"
+  <?= $listingsActive ? '' : 'hidden'; ?>
+>
+  <header class="manager-panel__header">
+    <div>
+      <h3 class="manager-panel__title">Listings</h3>
+      <p class="manager-panel__description">Filter by status, adjust tags, and move listings through their lifecycle.</p>
+    </div>
+    <div class="manager-panel__toolbar">
+      <a class="btn" href="/sell.php">Create listing</a>
+      <form class="manager-panel__filters" method="get" action="/shop-manager/index.php" data-manager-filters="listings">
+        <input type="hidden" name="tab" value="listings">
+        <label class="manager-filter">
+          <span class="manager-filter__label">Search</span>
+          <input type="search" name="search" value="<?= htmlspecialchars($listingsSearch, ENT_QUOTES, 'UTF-8'); ?>" placeholder="Search listings">
+        </label>
+        <label class="manager-filter">
+          <span class="manager-filter__label">Status</span>
+          <select name="status">
+            <option value="">All statuses</option>
+            <?php foreach ($listingsStatuses as $status): ?>
+              <option value="<?= htmlspecialchars($status, ENT_QUOTES, 'UTF-8'); ?>" <?= $status === $listingsStatus ? 'selected' : ''; ?>><?= htmlspecialchars(ucfirst($status), ENT_QUOTES, 'UTF-8'); ?></option>
+            <?php endforeach; ?>
+          </select>
+        </label>
+        <label class="manager-filter">
+          <span class="manager-filter__label">Per page</span>
+          <select name="per_page">
+            <?php foreach ([10, 25, 50] as $option): ?>
+              <option value="<?= $option; ?>" <?= $option === $listingsPerPage ? 'selected' : ''; ?>><?= $option; ?></option>
+            <?php endforeach; ?>
+          </select>
+        </label>
+        <button type="submit" class="btn btn-small">Apply</button>
+      </form>
+    </div>
+  </header>
+
+  <?php if ($listingsItems): ?>
+  <div class="table-wrapper">
+    <table class="store-table manager-table" data-manager-controller="listings">
+      <thead>
+        <tr>
+          <th scope="col">Listing</th>
+          <th scope="col">Status</th>
+          <th scope="col">Quantity</th>
+          <th scope="col">Reserved</th>
+          <th scope="col">Tags</th>
+          <th scope="col">Updated</th>
+          <th scope="col" class="store-table__actions">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($listingsItems as $item): ?>
+          <?php
+            $listingId = (int) $item['id'];
+            $tagInput = tags_to_input_value($item['tags']);
+            $filtersState = [
+              'status' => $listingsStatus,
+              'search' => $listingsSearch,
+              'page' => $listingsPage,
+              'per_page' => $listingsPerPage,
+            ];
+          ?>
+          <tr data-listing-id="<?= $listingId; ?>">
+            <th scope="row">
+              <strong><?= htmlspecialchars($item['title'], ENT_QUOTES, 'UTF-8'); ?></strong><br>
+              <small>
+                <?= htmlspecialchars($item['category'] ?: 'Uncategorised', ENT_QUOTES, 'UTF-8'); ?>
+                <?php if ($item['pickup_only']): ?> · Pickup only<?php endif; ?>
+              </small><br>
+              <small>Created <?= htmlspecialchars((string) $item['created_at'], ENT_QUOTES, 'UTF-8'); ?></small>
+            </th>
+            <td>
+              <form method="post" class="manager-status-form" data-manager-action="status">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="tab" value="listings">
+                <input type="hidden" name="manager_action" value="update_listing_status">
+                <input type="hidden" name="listing_id" value="<?= $listingId; ?>">
+                <?php foreach ($filtersState as $key => $value): ?>
+                  <input type="hidden" name="filters[<?= htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>]" value="<?= htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8'); ?>">
+                <?php endforeach; ?>
+                <label class="sr-only" for="listing-status-<?= $listingId; ?>">Listing status</label>
+                <select id="listing-status-<?= $listingId; ?>" name="status">
+                  <?php foreach ($listingsStatuses as $status): ?>
+                    <option value="<?= htmlspecialchars($status, ENT_QUOTES, 'UTF-8'); ?>" <?= $status === $item['status'] ? 'selected' : ''; ?>><?= htmlspecialchars(ucfirst($status), ENT_QUOTES, 'UTF-8'); ?></option>
+                  <?php endforeach; ?>
+                </select>
+                <button type="submit" class="btn btn-small">Update</button>
+              </form>
+            </td>
+            <td data-field="quantity"><?= $item['quantity'] !== null ? (int) $item['quantity'] : '—'; ?></td>
+            <td data-field="reserved"><?= $item['reserved_qty'] !== null ? (int) $item['reserved_qty'] : '—'; ?></td>
+            <td class="manager-tags">
+              <div class="tag-badges">
+                <?php if ($item['tags']): ?>
+                  <?php foreach ($item['tags'] as $tag): ?>
+                    <span class="tag-chip tag-chip-static"><?= htmlspecialchars($tag, ENT_QUOTES, 'UTF-8'); ?></span>
+                  <?php endforeach; ?>
+                <?php else: ?>
+                  <span class="tag-empty">No tags</span>
+                <?php endif; ?>
+              </div>
+              <form method="post" class="manager-tags-form" data-manager-action="tags">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="tab" value="listings">
+                <input type="hidden" name="manager_action" value="update_listing_tags">
+                <input type="hidden" name="listing_id" value="<?= $listingId; ?>">
+                <?php foreach ($filtersState as $key => $value): ?>
+                  <input type="hidden" name="filters[<?= htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>]" value="<?= htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8'); ?>">
+                <?php endforeach; ?>
+                <div class="tag-input" data-tag-editor>
+                  <div class="tag-list" data-tag-list></div>
+                  <input type="text" data-tag-source placeholder="Add tag">
+                  <input type="hidden" name="tags" value="<?= htmlspecialchars($tagInput, ENT_QUOTES, 'UTF-8'); ?>" data-tag-store>
+                </div>
+                <div class="manager-tags__actions">
+                  <button type="submit" class="btn btn-small">Save</button>
+                </div>
+              </form>
+            </td>
+            <td><?= htmlspecialchars((string) ($item['updated_at'] ?? '—'), ENT_QUOTES, 'UTF-8'); ?></td>
+            <td class="store-table__actions">
+              <?php if (!empty($squareSyncAvailable)): ?>
+              <form method="post" class="manager-sync-form" data-manager-action="sync">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="tab" value="listings">
+                <input type="hidden" name="manager_action" value="sync_listing">
+                <input type="hidden" name="listing_id" value="<?= $listingId; ?>">
+                <?php foreach ($filtersState as $key => $value): ?>
+                  <input type="hidden" name="filters[<?= htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>]" value="<?= htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8'); ?>">
+                <?php endforeach; ?>
+                <button type="submit" class="btn btn-secondary btn-small">Sync to Square</button>
+              </form>
+              <?php if (!empty($item['square_sync_status'])): ?>
+                <small class="manager-sync-status">Square: <?= htmlspecialchars((string) $item['square_sync_status'], ENT_QUOTES, 'UTF-8'); ?></small>
+              <?php endif; ?>
+              <?php endif; ?>
+              <form method="post" class="manager-delete-form" data-manager-action="delete" onsubmit="return confirm('Delete this listing?');">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="tab" value="listings">
+                <input type="hidden" name="manager_action" value="delete_listing">
+                <input type="hidden" name="listing_id" value="<?= $listingId; ?>">
+                <?php foreach ($filtersState as $key => $value): ?>
+                  <input type="hidden" name="filters[<?= htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>]" value="<?= htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8'); ?>">
+                <?php endforeach; ?>
+                <button type="submit" class="btn btn-secondary btn-small">Delete</button>
+              </form>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+
+  <?php if ($listingsPageCount > 1): ?>
+    <nav class="manager-pagination" aria-label="Listing pagination">
+      <ul>
+        <?php for ($page = 1; $page <= $listingsPageCount; $page++): ?>
+          <?php
+            $query = $paginationQuery;
+            $query['page'] = $page;
+            $url = '/shop-manager/index.php?' . http_build_query(array_filter($query, static function ($value) {
+                return $value !== '' && $value !== null;
+            }));
+          ?>
+          <li class="<?= $page === $listingsPage ? 'is-active' : ''; ?>">
+            <a href="<?= htmlspecialchars($url, ENT_QUOTES, 'UTF-8'); ?>" aria-current="<?= $page === $listingsPage ? 'page' : 'false'; ?>">
+              <?= $page; ?>
+            </a>
+          </li>
+        <?php endfor; ?>
+      </ul>
+      <p class="manager-pagination__summary">Showing page <?= $listingsPage; ?> of <?= $listingsPageCount; ?> (<?= $listingsTotal; ?> total listings)</p>
+    </nav>
+  <?php endif; ?>
+  <?php else: ?>
+    <p class="notice">No listings match the selected filters.</p>
+  <?php endif; ?>
+</section>

--- a/shop-manager/orders.php
+++ b/shop-manager/orders.php
@@ -1,0 +1,88 @@
+<?php
+$ordersActive = $activeTab === 'orders';
+$ordersPanelId = 'shop-manager-panel-orders';
+$ordersTabId = 'shop-manager-tab-orders';
+?>
+<section
+  id="<?= htmlspecialchars($ordersPanelId, ENT_QUOTES, 'UTF-8'); ?>"
+  class="store__panel<?= $ordersActive ? ' is-active' : ''; ?>"
+  role="tabpanel"
+  aria-labelledby="<?= htmlspecialchars($ordersTabId, ENT_QUOTES, 'UTF-8'); ?>"
+  data-manager-panel="orders"
+  data-repository="orders"
+  <?= $ordersActive ? '' : 'hidden'; ?>
+>
+  <header class="manager-panel__header">
+    <div>
+      <h3 class="manager-panel__title">Orders</h3>
+      <p class="manager-panel__description">Monitor purchase flow across marketplace, service, and trade channels.</p>
+    </div>
+  </header>
+
+  <?php if ($orders): ?>
+  <div class="table-wrapper">
+    <table class="store-table" data-manager-controller="orders">
+      <thead>
+        <tr>
+          <th scope="col">Order</th>
+          <th scope="col">Product</th>
+          <th scope="col">Direction</th>
+          <th scope="col">Payment</th>
+          <th scope="col">Shipping</th>
+          <th scope="col">Counterparty</th>
+          <th scope="col">Placed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($orders as $order): ?>
+          <?php
+            $badges = [];
+            if (!empty($order['listing']['is_official']) || !empty($order['product']['is_skuze_official']) || !empty($order['is_official_order'])) {
+                $badges[] = ['class' => 'badge-official', 'label' => 'SkuzE Official'];
+            }
+            if (!empty($order['product']['is_skuze_product'])) {
+                $badges[] = ['class' => 'badge-product', 'label' => 'SkuzE Product'];
+            }
+            if (!$badges) {
+                $badges[] = ['class' => 'badge-community', 'label' => 'Community'];
+            }
+            $amount = $order['payment']['amount'] ?? null;
+            $amountDisplay = $amount !== null ? '$' . number_format(((int) $amount) / 100, 2) : '—';
+            $paymentStatus = $order['payment']['status'] ?? 'pending';
+            $shippingStatus = $order['shipping_status'] ?? 'pending';
+            $counterparty = $order['direction'] === 'sell'
+                ? ($order['buyer']['username'] ?? 'Buyer')
+                : ($order['listing']['owner_username'] ?? 'Seller');
+          ?>
+          <tr data-order-id="<?= (int) $order['id']; ?>">
+            <th scope="row">#<?= (int) $order['id']; ?></th>
+            <td>
+              <?php foreach ($badges as $badge): ?>
+                <span class="badge <?= htmlspecialchars($badge['class'], ENT_QUOTES, 'UTF-8'); ?>"><?= htmlspecialchars($badge['label'], ENT_QUOTES, 'UTF-8'); ?></span>
+              <?php endforeach; ?>
+              <?= htmlspecialchars($order['product']['title'] ?: $order['listing']['title'], ENT_QUOTES, 'UTF-8'); ?>
+            </td>
+            <td><?= htmlspecialchars(ucfirst((string) $order['direction']), ENT_QUOTES, 'UTF-8'); ?></td>
+            <td>
+              <?= htmlspecialchars($amountDisplay, ENT_QUOTES, 'UTF-8'); ?><br>
+              <small>Status: <?= htmlspecialchars(ucfirst((string) $paymentStatus), ENT_QUOTES, 'UTF-8'); ?></small>
+            </td>
+            <td class="store-orders__shipping" data-order-field="shipping">
+              <span class="store-orders__shipping-status" data-field="status"><?= htmlspecialchars(ucfirst((string) $shippingStatus), ENT_QUOTES, 'UTF-8'); ?></span>
+              <span class="store-orders__tracking" data-field="tracking">
+                <?php if (!empty($order['tracking_number'])): ?>
+                  <br><small>Tracking: <?= htmlspecialchars($order['tracking_number'], ENT_QUOTES, 'UTF-8'); ?></small>
+                <?php endif; ?>
+              </span>
+            </td>
+            <td><?= htmlspecialchars($counterparty ?? '—', ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?= htmlspecialchars($order['placed_at'] ?? '—', ENT_QUOTES, 'UTF-8'); ?></td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <?php else: ?>
+    <p class="notice">No orders are available for review yet.</p>
+  <?php endif; ?>
+</section>

--- a/shop-manager/settings.php
+++ b/shop-manager/settings.php
@@ -1,0 +1,47 @@
+<?php
+$settingsActive = $activeTab === 'settings';
+$settingsPanelId = 'shop-manager-panel-settings';
+$settingsTabId = 'shop-manager-tab-settings';
+?>
+<section
+  id="<?= htmlspecialchars($settingsPanelId, ENT_QUOTES, 'UTF-8'); ?>"
+  class="store__panel<?= $settingsActive ? ' is-active' : ''; ?>"
+  role="tabpanel"
+  aria-labelledby="<?= htmlspecialchars($settingsTabId, ENT_QUOTES, 'UTF-8'); ?>"
+  data-manager-panel="settings"
+  data-repository="settings"
+  <?= $settingsActive ? '' : 'hidden'; ?>
+>
+  <header class="manager-panel__header">
+    <div>
+      <h3 class="manager-panel__title">Settings</h3>
+      <p class="manager-panel__description">Control default fulfillment preferences and connect external catalogues.</p>
+    </div>
+  </header>
+
+  <form class="manager-settings" method="post" data-manager-controller="settings" data-manager-form>
+    <fieldset>
+      <legend>Fulfillment defaults</legend>
+      <label class="manager-toggle">
+        <input type="checkbox" name="auto_accept_orders" value="1">
+        <span>Automatically accept paid orders</span>
+      </label>
+      <label class="manager-toggle">
+        <input type="checkbox" name="notify_on_inventory_low" value="1" checked>
+        <span>Notify me when stock drops below threshold</span>
+      </label>
+    </fieldset>
+
+    <fieldset>
+      <legend>Integrations</legend>
+      <p class="field-hint">Square catalog sync will be available once the repository services are provisioned.</p>
+      <label class="manager-toggle manager-toggle--disabled">
+        <input type="checkbox" name="square_sync" value="1" disabled>
+        <span>Enable Square catalog sync</span>
+      </label>
+    </fieldset>
+
+    <p class="notice">Settings are stored via the forthcoming shop manager services. Changes made here will synchronise once the backend is activated.</p>
+    <button type="submit" class="btn" disabled>Save preferences</button>
+  </form>
+</section>

--- a/shop-manager/shipping.php
+++ b/shop-manager/shipping.php
@@ -1,0 +1,83 @@
+<?php
+$shippingActive = $activeTab === 'shipping';
+$shippingPanelId = 'shop-manager-panel-shipping';
+$shippingTabId = 'shop-manager-tab-shipping';
+?>
+<section
+  id="<?= htmlspecialchars($shippingPanelId, ENT_QUOTES, 'UTF-8'); ?>"
+  class="store__panel<?= $shippingActive ? ' is-active' : ''; ?>"
+  role="tabpanel"
+  aria-labelledby="<?= htmlspecialchars($shippingTabId, ENT_QUOTES, 'UTF-8'); ?>"
+  data-manager-panel="shipping"
+  data-repository="shipping"
+  <?= $shippingActive ? '' : 'hidden'; ?>
+>
+  <header class="manager-panel__header">
+    <div>
+      <h3 class="manager-panel__title">Shipping</h3>
+      <p class="manager-panel__description">Update fulfillment statuses and capture tracking numbers as orders move.</p>
+    </div>
+  </header>
+
+  <?php if ($shipping): ?>
+  <div class="table-wrapper">
+    <table class="store-table" data-manager-controller="shipping">
+      <thead>
+        <tr>
+          <th scope="col">Order</th>
+          <th scope="col">Product</th>
+          <th scope="col">Status</th>
+          <th scope="col">Tracking</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($shipping as $order): ?>
+          <?php
+            $statusValue = strtolower((string) ($order['shipping_status'] ?? 'pending'));
+            $trackingValue = $order['tracking_number'] ?? '';
+            $orderId = (int) $order['id'];
+          ?>
+          <tr class="store-shipping" data-order-id="<?= $orderId; ?>">
+            <th scope="row">#<?= $orderId; ?></th>
+            <td>
+              <?= htmlspecialchars($order['product']['title'] ?: $order['listing']['title'], ENT_QUOTES, 'UTF-8'); ?>
+              <?php if (!empty($order['product']['is_skuze_product'])): ?>
+                <span class="badge badge-product">SkuzE Product</span>
+              <?php endif; ?>
+              <?php if (!empty($order['listing']['is_official']) || !empty($order['product']['is_skuze_official']) || !empty($order['is_official_order'])): ?>
+                <span class="badge badge-official">SkuzE Official</span>
+              <?php endif; ?>
+            </td>
+            <td class="store-shipping__status">
+              <form class="store-shipping__status-form" method="post" action="/account/order_update_status.php">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="order_id" value="<?= $orderId; ?>">
+                <label class="sr-only" for="order-status-<?= $orderId; ?>">Fulfillment status</label>
+                <select id="order-status-<?= $orderId; ?>" name="status">
+                  <?php foreach ($fulfillmentStatusOptions as $value => $label): ?>
+                    <option value="<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8'); ?>" <?= $statusValue === $value ? 'selected' : ''; ?>><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?></option>
+                  <?php endforeach; ?>
+                </select>
+                <button type="submit" class="btn btn-small">Update</button>
+              </form>
+            </td>
+            <td class="store-shipping__tracking" data-field="tracking">
+              <form class="store-shipping__tracking-form" method="post" action="/account/order_add_tracking.php">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="order_id" value="<?= $orderId; ?>">
+                <label class="sr-only" for="order-tracking-<?= $orderId; ?>">Tracking number</label>
+                <div class="store-shipping__tracking-inputs">
+                  <input id="order-tracking-<?= $orderId; ?>" type="text" name="tracking_number" value="<?= htmlspecialchars($trackingValue, ENT_QUOTES, 'UTF-8'); ?>" maxlength="100" placeholder="Add tracking">
+                  <button type="submit" class="btn btn-small">Save</button>
+                </div>
+              </form>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <?php else: ?>
+    <p class="notice">No shipments currently require action.</p>
+  <?php endif; ?>
+</section>

--- a/trade-listing-delete.php
+++ b/trade-listing-delete.php
@@ -1,10 +1,11 @@
 <?php
 require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/authz.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 
 $user_id = $_SESSION['user_id'] ?? null;
-$is_admin = is_admin();
+$is_admin = authz_has_role('admin');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && validate_token($_POST['csrf_token'] ?? '')) {
     $id = intval($_POST['id'] ?? 0);

--- a/trade-offer-delete.php
+++ b/trade-offer-delete.php
@@ -1,10 +1,15 @@
 <?php
 require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/authz.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/trade.php';
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && validate_token($_POST['csrf_token'] ?? '') && is_admin()) {
+if (
+    $_SERVER['REQUEST_METHOD'] === 'POST'
+    && validate_token($_POST['csrf_token'] ?? '')
+    && authz_has_role('admin')
+) {
     $id = intval($_POST['id'] ?? 0);
     if ($id) {
         $actorId = isset($_SESSION['user_id']) ? (int)$_SESSION['user_id'] : null;


### PR DESCRIPTION
## Summary
- add ListingsRepo, InventoryService, OrdersService, ChangeRequestsService, ShopLogger, and SquareCatalogSync to centralize listing lifecycle, inventory adjustments, order fulfillment, and Square sync auditing
- refactor shop manager, admin listing review, seller creation flow, and shared store helpers to rely on the new services with review-aware status transitions, reservation/capture APIs, and Square sync actions
- update checkout processing to reserve inventory before payment, capture or release quantities via the services, and log actions to logs/shop.log while exposing the Square sync feature flag in configuration

## Testing
- for file in includes/repositories/ChangeRequestsService.php includes/repositories/ListingsRepo.php includes/repositories/InventoryService.php includes/repositories/OrdersService.php includes/repositories/SquareCatalogSync.php shop-manager/index.php shop-manager/listings.php includes/shop_manager.php sell.php admin/listings.php includes/store.php checkout_process.php; do php -l $file || break; done
- php -l includes/repositories/ShopLogger.php
- php -l config.example.php
- php -l includes/repositories/OrdersService.php

------
https://chatgpt.com/codex/tasks/task_e_68ce70d6277c832bb40362805ed07f05