### PR TITLE
Harden login and request handling

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,21 @@
+# Security hardening rules for Apache-compatible environments.
+# If your deployment does not use .htaccess, equivalent headers and
+# request filters are applied via includes/security.php.
+
+# Block direct access to version control and environment files.
+RedirectMatch 404 ^/(\.git|\.svn|\.hg)(/|$)
+RedirectMatch 404 ^/(\.|_)?env$
+RedirectMatch 404 ^/composer\.(json|lock)$
+
+# Deny access to other dotfiles.
+<FilesMatch "^\\.(.*)$">
+    Require all denied
+</FilesMatch>
+
+<IfModule mod_headers.c>
+    Header set X-Content-Type-Options "nosniff"
+    Header set X-Frame-Options "SAMEORIGIN"
+    Header set Referrer-Policy "strict-origin-when-cross-origin"
+    Header set Permissions-Policy "camera=(), microphone=(), geolocation=()"
+    Header set Content-Security-Policy "default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' data: https:; connect-src 'self' https:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'"
+</IfModule>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Hardening Summary
+
+This patch introduces light-weight application defenses in response to recent probing and brute-force activity.
+
+## Request Filtering
+- `.htaccess` blocks requests for VCS metadata (`.git`, `.svn`, `.hg`), environment files (`.env`, `_env`), Composer manifests, and any other hidden dotfiles. Equivalent PHP fallbacks live in `includes/security.php` for environments that do not honor `.htaccess`.
+- PHP fallback (`enforce_sensitive_path_blocklist`) returns a 404 and records a security event when those paths are requested.
+
+## Response Headers
+- Security headers are set twice for redundancy: via `.htaccess` (when Apache modules are available) and `send_security_headers()` in `includes/security.php`. The headers include `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and a conservative Content-Security-Policy. Adjust the CSP in `.htaccess` and/or `includes/security.php` if assets are blocked.
+- `send_no_store_headers()` emits `Cache-Control`, `Pragma`, and `Expires` directives for sensitive views such as `login.php`.
+
+## Authentication Flow
+- `includes/auth.php` now exposes `is_authenticated()` and `require_auth()` helpers without forcing an automatic redirect. `includes/require-auth.php` wraps these helpers for pages that must be protected.
+- `login.php` now sends no-store headers, redirects authenticated users to the dashboard, verifies a CSRF token, tracks failures in both the database and the session, adds a 10-minute rolling window throttle (sleeping before extra attempts), and logs throttled attempts through `log_security_event()`.
+
+## Robots and Logging
+- `robots.txt` discourages crawlers from noisy or private directories (`/.git/`, `/vendor/`, `/node_modules/`, `/admin/`) while allowing public assets.
+- Security-relevant events append to `logs/security.log` (directory tracked with a `.gitignore`). Only sensitive-path blocks and excessive login attempts are recorded to reduce noise.
+
+## Operational Notes
+- Consider enabling a CDN/WAF bot mitigation or rate-limiter for `/login.php` and explicit rules to drop `/.git/*` probes at the edge.
+- If additional third-party assets are introduced, pair them with Subresource Integrity (SRI) attributes and update the CSP accordingly.
+- Periodically review `logs/security.log` and rotate it through logrotate or the hosting control panel.

--- a/about.php
+++ b/about.php
@@ -1,4 +1,4 @@
-<?php require_once __DIR__ . '/includes/auth.php'; ?>
+<?php require_once __DIR__ . '/includes/require-auth.php'; ?>
 <?php require 'includes/layout.php'; ?>
   <meta charset="UTF-8">
   <title>About SkuzE</title>

--- a/account/order_add_tracking.php
+++ b/account/order_add_tracking.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/store.php';
 require_once __DIR__ . '/../includes/csrf.php';

--- a/account/order_update_status.php
+++ b/account/order_update_status.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/store.php';
 require_once __DIR__ . '/../includes/csrf.php';

--- a/account/store.php
+++ b/account/store.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/store.php';
 require_once __DIR__ . '/../includes/csrf.php';

--- a/account/store_inventory_update.php
+++ b/account/store_inventory_update.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/store.php';
 require_once __DIR__ . '/../includes/csrf.php';

--- a/admin/discount-codes.php
+++ b/admin/discount-codes.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/csrf.php';

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/user.php';

--- a/admin/listings.php
+++ b/admin/listings.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/user.php';

--- a/admin/order-update.php
+++ b/admin/order-update.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/orders.php';

--- a/admin/order.php
+++ b/admin/order.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/orders.php';
 require '../includes/csrf.php';

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/orders.php';
 require '../includes/csrf.php';

--- a/admin/products.php
+++ b/admin/products.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/csrf.php';

--- a/admin/support.php
+++ b/admin/support.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/csrf.php';

--- a/admin/theme.php
+++ b/admin/theme.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/theme_store.php';
 

--- a/admin/theme_save.php
+++ b/admin/theme_save.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/theme_store.php';
 

--- a/admin/toolbox.php
+++ b/admin/toolbox.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/csrf.php';
 

--- a/admin/trade-requests.php
+++ b/admin/trade-requests.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/user.php';

--- a/admin/user-edit.php
+++ b/admin/user-edit.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/user.php';

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/user.php';

--- a/admin/view.php
+++ b/admin/view.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/csrf.php';

--- a/api/listings.php
+++ b/api/listings.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require __DIR__ . '/../includes/db.php';
 require __DIR__ . '/../includes/listing-query.php';
 require __DIR__ . '/../includes/user.php';

--- a/auth.php
+++ b/auth.php
@@ -1,2 +1,2 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';

--- a/buy-step.php
+++ b/buy-step.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 
 $category = $_GET['category'] ?? '';

--- a/buy.php
+++ b/buy.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/tags.php';

--- a/cancel.php
+++ b/cancel.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 require __DIR__ . '/_debug_bootstrap.php';
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 ?>
 <?php require 'includes/layout.php'; ?>
   <title>Payment Canceled</title>

--- a/checkout.php
+++ b/checkout.php
@@ -3,7 +3,7 @@ require __DIR__ . '/_debug_bootstrap.php';
 $client = require __DIR__ . '/includes/square.php';
 $squareConfig = require __DIR__ . '/includes/square-config.php';
 require 'includes/requirements.php';
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/url.php';
 

--- a/checkout_process.php
+++ b/checkout_process.php
@@ -11,7 +11,7 @@ require __DIR__ . '/_debug_bootstrap.php';
  *   - listing_id          (int) server computes price
  */
 
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 $maybeDb = require __DIR__ . '/includes/db.php';  // may return mysqli OR set $conn/$mysqli
 $config  = require __DIR__ . '/config.php';
 require_once __DIR__ . '/includes/repositories/InventoryService.php';

--- a/compose-message.php
+++ b/compose-message.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/notifications.php';

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/notifications.php';
 require 'includes/orders.php';

--- a/edit-profile.php
+++ b/edit-profile.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 
 $userId = $_SESSION['user_id'];

--- a/escrow.php
+++ b/escrow.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/followers.php
+++ b/followers.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/user.php';
 
 $id = $_SESSION['user_id'];

--- a/forum/index.php
+++ b/forum/index.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require '../includes/csrf.php';
 require '../includes/user.php';
 

--- a/forum/thread.php
+++ b/forum/thread.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require '../includes/csrf.php';
 require '../includes/user.php';
 

--- a/friend-requests.php
+++ b/friend-requests.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 require 'includes/user.php';
 require 'includes/notifications.php';

--- a/friend-search.php
+++ b/friend-search.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 require 'includes/user.php';
 require 'includes/notifications.php';

--- a/help.php
+++ b/help.php
@@ -1,4 +1,4 @@
-<?php require_once __DIR__ . '/includes/auth.php'; ?>
+<?php require_once __DIR__ . '/includes/require-auth.php'; ?>
 <?php require 'includes/layout.php'; ?>
   <meta charset="UTF-8">
   <title>Help & FAQ</title>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,19 +1,13 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) {
-  if (headers_sent($sentFile, $sentLine)) {
-    trigger_error(
-      sprintf('Unable to start session because headers were sent in %s on line %d.', $sentFile, $sentLine),
-      E_USER_WARNING
-    );
-  } else {
-    session_start();
-  }
-}
+require_once __DIR__ . '/auth.php';
 
 $headerRequiresAuth = !defined('HEADER_SKIP_AUTH') || HEADER_SKIP_AUTH !== true;
+
+auth_bootstrap();
 if ($headerRequiresAuth) {
-  require_once __DIR__ . '/auth.php';
+  require_auth();
 }
+
 $db = require __DIR__ . '/db.php';
 require_once __DIR__ . '/user.php';
 require_once __DIR__ . '/notifications.php';

--- a/includes/require-auth.php
+++ b/includes/require-auth.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/auth.php';
+
+require_auth();

--- a/includes/security.php
+++ b/includes/security.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Append security events to logs/security.log for analyst review.
+ */
+function log_security_event(string $message): void
+{
+    $logDir = __DIR__ . '/../logs';
+    if (!is_dir($logDir)) {
+        @mkdir($logDir, 0755, true);
+    }
+
+    $ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+    $agent = $_SERVER['HTTP_USER_AGENT'] ?? '-';
+    $line = sprintf(
+        "[%s] %s | ip=%s | ua=%s%s",
+        gmdate('c'),
+        $message,
+        $ip,
+        $agent,
+        PHP_EOL
+    );
+
+    @file_put_contents($logDir . '/security.log', $line, FILE_APPEND | LOCK_EX);
+}
+
+/**
+ * Ensure security headers are delivered even when .htaccess is ignored.
+ */
+function send_security_headers(): void
+{
+    static $sent = false;
+
+    if ($sent || headers_sent()) {
+        return;
+    }
+
+    $existing = array_change_key_case(array_reduce(
+        headers_list(),
+        static function (array $carry, string $header): array {
+            [$name] = explode(':', $header, 2);
+            $carry[trim(strtolower($name))] = true;
+
+            return $carry;
+        },
+        []
+    ));
+
+    $headers = [
+        'X-Content-Type-Options' => 'nosniff',
+        'X-Frame-Options' => 'SAMEORIGIN',
+        'Referrer-Policy' => 'strict-origin-when-cross-origin',
+        'Permissions-Policy' => 'camera=(), microphone=(), geolocation=()',
+        'Content-Security-Policy' => "default-src 'self'; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; font-src 'self' data: https:; connect-src 'self' https:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'",
+    ];
+
+    foreach ($headers as $name => $value) {
+        $key = strtolower($name);
+        if (!isset($existing[$key])) {
+            header($name . ': ' . $value);
+        }
+    }
+
+    $sent = true;
+}
+
+/**
+ * Send cache-prevention headers for sensitive views (e.g., login.php).
+ */
+function send_no_store_headers(): void
+{
+    if (headers_sent()) {
+        return;
+    }
+
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    header('Expires: 0');
+}
+
+/**
+ * PHP fallback for sensitive path blocking when rewrite rules are unavailable.
+ */
+function enforce_sensitive_path_blocklist(): void
+{
+    static $checked = false;
+
+    if ($checked) {
+        return;
+    }
+
+    $checked = true;
+    $path = (string) parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+
+    $patterns = [
+        '#^/(\\.git|\\.svn|\\.hg)(/|$)#i',
+        '#^/(\.|_)?env$#i',
+        '#^/composer\\.(json|lock)$#i',
+    ];
+
+    foreach ($patterns as $pattern) {
+        if (preg_match($pattern, $path)) {
+            log_security_event('Blocked sensitive path request: ' . $path);
+            http_response_code(404);
+            exit;
+        }
+    }
+
+    $basename = basename($path);
+    if ($basename !== '' && $basename[0] === '.' && strpos($path, '/.well-known') !== 0) {
+        log_security_event('Blocked hidden file request: ' . $path);
+        http_response_code(404);
+        exit;
+    }
+}
+
+if (!defined('SECURITY_HELPERS_BOOTSTRAPPED')) {
+    define('SECURITY_HELPERS_BOOTSTRAPPED', true);
+    enforce_sensitive_path_blocklist();
+    send_security_headers();
+}

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 require __DIR__ . '/_debug_bootstrap.php';
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 ?>
 <?php require 'includes/layout.php'; ?>
 <?php require 'includes/components.php'; ?>

--- a/listing-delete.php
+++ b/listing-delete.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/listing.php
+++ b/listing.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/tags.php';

--- a/login.php
+++ b/login.php
@@ -1,125 +1,164 @@
 <?php
-require 'includes/csrf.php';
-require 'includes/db.php';
-require 'includes/totp.php';
+require_once __DIR__ . '/includes/security.php';
+require_once __DIR__ . '/includes/csrf.php';
+require_once __DIR__ . '/includes/db.php';
+require_once __DIR__ . '/includes/totp.php';
+require_once __DIR__ . '/includes/auth.php';
 
 if (!defined('HEADER_SKIP_AUTH')) {
   define('HEADER_SKIP_AUTH', true);
 }
 
-$ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
-$maxAttempts = 5;
-$lockout = 300; // seconds
-$twofaStage = !empty($_SESSION['pending_2fa']);
+auth_bootstrap(false);
+send_no_store_headers();
 
-// Clean up old login attempts and count recent failures for this IP
-$conn->query("DELETE FROM login_attempts WHERE attempt_time < (NOW() - INTERVAL $lockout SECOND)");
-$attempts = 0;
-$stmt = $conn->prepare("SELECT COUNT(*) FROM login_attempts WHERE ip = ? AND attempt_time > (NOW() - INTERVAL ? SECOND)");
-if ($stmt === false) {
-  error_log('Prepare failed for login_attempts: ' . $conn->error);
-  if ($conn->errno === 1146) {
-    $error = "Login is temporarily unavailable. Please contact support.";
-  } else {
-    $error = "Database error.";
-  }
-} else {
-  $stmt->bind_param('si', $ip, $lockout);
-  if ($stmt->execute()) {
-    $stmt->bind_result($attempts);
-    $stmt->fetch();
-  } else {
-    error_log('Execute failed for login_attempts: ' . $stmt->error);
-    $error = "Database error.";
-  }
-  $stmt->close();
-  if ($attempts >= $maxAttempts) {
-    $error = "Too many failed login attempts. Please try again later.";
-  }
+if (is_authenticated()) {
+  header('Location: /dashboard.php');
+  exit;
 }
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && empty($error)) {
+$ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+$maxAttempts = 5;
+$lockout = 600; // seconds
+$twofaStage = !empty($_SESSION['pending_2fa']);
+$error = '';
+$now = time();
+
+$sessionKey = 'login_failures';
+if (!isset($_SESSION[$sessionKey]) || !is_array($_SESSION[$sessionKey])) {
+  $_SESSION[$sessionKey] = [];
+}
+$sessionAttempts = $_SESSION[$sessionKey][$ip] ?? [];
+$sessionAttempts = array_values(array_filter($sessionAttempts, static function ($ts) use ($now, $lockout) {
+  return ($now - (int) $ts) < $lockout;
+}));
+$_SESSION[$sessionKey][$ip] = $sessionAttempts;
+$sessionFailureCount = count($sessionAttempts);
+
+$dbFailures = 0;
+try {
+  $conn->query("DELETE FROM login_attempts WHERE attempt_time < (NOW() - INTERVAL $lockout SECOND)");
+  if ($stmt = $conn->prepare("SELECT COUNT(*) FROM login_attempts WHERE ip = ? AND attempt_time > (NOW() - INTERVAL ? SECOND)")) {
+    $stmt->bind_param('si', $ip, $lockout);
+    if ($stmt->execute()) {
+      $stmt->bind_result($dbFailures);
+      $stmt->fetch();
+    }
+    $stmt->close();
+  }
+} catch (Throwable $e) {
+  error_log('Login throttle query failed: ' . $e->getMessage());
+}
+
+$aggregateFailures = max($dbFailures, $sessionFailureCount);
+
+$throttleLogKey = 'login_throttle_notified';
+if (!isset($_SESSION[$throttleLogKey]) || !is_array($_SESSION[$throttleLogKey])) {
+  $_SESSION[$throttleLogKey] = [];
+}
+$logThrottle = static function (int $count, string $username = '') use ($ip, $throttleLogKey, $now) {
+  if (empty($_SESSION[$throttleLogKey][$ip])) {
+    $username = trim(preg_replace('/\s+/', ' ', $username));
+    $userNote = $username !== '' ? ' username=' . $username : '';
+    log_security_event(sprintf('Login throttled for %s after %d failures%s', $ip, $count, $userNote));
+    $_SESSION[$throttleLogKey][$ip] = $now;
+  }
+};
+
+$recordFailure = function () use (&$sessionAttempts, $sessionKey, $ip, $now, $lockout, &$sessionFailureCount, &$aggregateFailures, &$dbFailures) {
+  $sessionAttempts[] = $now;
+  $sessionAttempts = array_values(array_filter($sessionAttempts, static function ($ts) use ($now, $lockout) {
+    return ($now - (int) $ts) < $lockout;
+  }));
+  $_SESSION[$sessionKey][$ip] = $sessionAttempts;
+  $sessionFailureCount = count($sessionAttempts);
+  $aggregateFailures = max($dbFailures + 1, $sessionFailureCount);
+  $dbFailures = max($dbFailures, $aggregateFailures);
+};
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if ($aggregateFailures >= $maxAttempts && !$twofaStage) {
+    sleep(2);
+  }
+
   if (!validate_token($_POST['csrf_token'] ?? '')) {
-    $error = "Invalid CSRF token.";
+    $error = 'Invalid CSRF token.';
   } elseif ($twofaStage) {
-    $code = trim($_POST['code'] ?? '');
-    $pendingId = $_SESSION['pending_2fa'];
-    $stmt = $conn->prepare("SELECT secret, recovery_code FROM user_2fa WHERE user_id = ?");
+    $code = trim((string) ($_POST['code'] ?? ''));
+    $pendingId = (int) ($_SESSION['pending_2fa'] ?? 0);
+    $stmt = $conn->prepare('SELECT secret, recovery_code FROM user_2fa WHERE user_id = ?');
     if ($stmt === false) {
       error_log('Prepare failed for user_2fa: ' . $conn->error);
-      if ($conn->errno === 1146) {
-        $error = "Two-factor authentication is not available. Please contact support.";
-      } else {
-        $error = "Database error.";
-      }
+      $error = $conn->errno === 1146
+        ? 'Two-factor authentication is not available. Please contact support.'
+        : 'Database error.';
     } else {
       $stmt->bind_param('i', $pendingId);
       if ($stmt->execute()) {
         $stmt->bind_result($secret, $recovery);
         $stmt->fetch();
         $stmt->close();
-        if (verify_totp($secret, $code) || hash_equals($recovery, $code)) {
+        if (verify_totp($secret, $code) || hash_equals((string) $recovery, $code)) {
           $_SESSION['user_id'] = $pendingId;
           $_SESSION['user_role'] = $_SESSION['pending_role'] ?? 'user';
           $_SESSION['is_admin'] = ($_SESSION['user_role'] ?? 'user') === 'admin' ? 1 : 0;
           unset($_SESSION['pending_2fa'], $_SESSION['pending_role']);
-          $clear = $conn->prepare("DELETE FROM login_attempts WHERE ip = ?");
-          if ($clear) {
+          if ($clear = $conn->prepare('DELETE FROM login_attempts WHERE ip = ?')) {
             $clear->bind_param('s', $ip);
             $clear->execute();
             $clear->close();
           }
-          header("Location: dashboard.php");
+          $_SESSION[$sessionKey][$ip] = [];
+          unset($_SESSION[$throttleLogKey][$ip]);
+          header('Location: dashboard.php');
           exit;
-        } else {
-          $error = "Invalid authentication code.";
         }
+
+        $error = 'Invalid authentication code.';
       } else {
         error_log('Execute failed for user_2fa: ' . $stmt->error);
-        $error = "Unable to verify two-factor authentication at this time.";
+        $error = 'Unable to verify two-factor authentication at this time.';
         $stmt->close();
       }
     }
+  } elseif ($aggregateFailures >= $maxAttempts) {
+    $error = 'Too many failed login attempts. Please try again in a few minutes.';
+    $logThrottle($aggregateFailures, (string) ($_POST['username'] ?? ''));
   } else {
-    $user = trim($_POST['username']);
-    $pass = $_POST['password'];
+    $user = trim((string) ($_POST['username'] ?? ''));
+    $pass = (string) ($_POST['password'] ?? '');
 
-    $stmt = $conn->prepare("SELECT id, password, is_verified, role, is_admin FROM users WHERE username = ?");
+    $stmt = $conn->prepare('SELECT id, password, is_verified, role FROM users WHERE username = ?');
     if ($stmt === false) {
       error_log('Prepare failed: ' . $conn->error);
-      $error = "Database error.";
+      $error = 'Database error.';
     } else {
-      $stmt->bind_param("s", $user);
+      $stmt->bind_param('s', $user);
       if (!$stmt->execute()) {
         error_log('Execute failed: ' . $stmt->error);
-        $error = "Database error.";
+        $error = 'Database error.';
       } else {
         $stmt->store_result();
 
         if ($stmt->num_rows === 1) {
-          $stmt->bind_result($id, $hash, $verified, $role, $admin);
+          $stmt->bind_result($id, $hash, $verified, $role);
           $stmt->fetch();
 
-          if (!password_verify($pass, $hash)) {
-            $error = "Incorrect password.";
-            $insert = $conn->prepare("INSERT INTO login_attempts (ip, attempt_time) VALUES (?, NOW())");
-            if ($insert) {
+          if (!password_verify($pass, (string) $hash)) {
+            $error = 'Incorrect username or password.';
+            if ($insert = $conn->prepare('INSERT INTO login_attempts (ip, attempt_time) VALUES (?, NOW())')) {
               $insert->bind_param('s', $ip);
-              if (!$insert->execute()) {
-                error_log('Execute failed for login_attempts insert: ' . $insert->error);
-              }
+              $insert->execute();
               $insert->close();
             }
-            $attempts++;
-            error_log("Failed login for $user from $ip");
-            if ($attempts >= $maxAttempts) {
-              error_log("IP $ip temporarily blocked after $attempts failed logins");
+            $recordFailure();
+            if ($aggregateFailures >= $maxAttempts) {
+              $logThrottle($aggregateFailures, $user);
             }
-          } elseif (!$verified) {
-            $error = "Please verify your email first.";
+          } elseif (!(int) $verified) {
+            $error = 'Please verify your email first.';
           } else {
-            $stmt2 = $conn->prepare("SELECT secret FROM user_2fa WHERE user_id = ?");
-            if ($stmt2) {
+            if ($stmt2 = $conn->prepare('SELECT secret FROM user_2fa WHERE user_id = ?')) {
               $stmt2->bind_param('i', $id);
               $stmt2->execute();
               $stmt2->store_result();
@@ -128,8 +167,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && empty($error)) {
                 $_SESSION['pending_role'] = $role ?: 'user';
                 $twofaStage = true;
               } else {
-                $clear = $conn->prepare("DELETE FROM login_attempts WHERE ip = ?");
-                if ($clear) {
+                if ($clear = $conn->prepare('DELETE FROM login_attempts WHERE ip = ?')) {
                   $clear->bind_param('s', $ip);
                   $clear->execute();
                   $clear->close();
@@ -137,26 +175,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && empty($error)) {
                 $_SESSION['user_id'] = $id;
                 $_SESSION['user_role'] = $role ?: 'user';
                 $_SESSION['is_admin'] = ($_SESSION['user_role'] ?? 'user') === 'admin' ? 1 : 0;
-                header("Location: dashboard.php");
+                $_SESSION[$sessionKey][$ip] = [];
+                unset($_SESSION[$throttleLogKey][$ip]);
+                header('Location: dashboard.php');
                 exit;
               }
               $stmt2->close();
             }
           }
         } else {
-          $error = "User not found.";
-          $insert = $conn->prepare("INSERT INTO login_attempts (ip, attempt_time) VALUES (?, NOW())");
-          if ($insert) {
+          $error = 'Incorrect username or password.';
+          if ($insert = $conn->prepare('INSERT INTO login_attempts (ip, attempt_time) VALUES (?, NOW())')) {
             $insert->bind_param('s', $ip);
-            if (!$insert->execute()) {
-              error_log('Execute failed for login_attempts insert: ' . $insert->error);
-            }
+            $insert->execute();
             $insert->close();
           }
-          $attempts++;
-          error_log("Failed login for $user from $ip");
-          if ($attempts >= $maxAttempts) {
-            error_log("IP $ip temporarily blocked after $attempts failed logins");
+          $recordFailure();
+          if ($aggregateFailures >= $maxAttempts) {
+            $logThrottle($aggregateFailures, $user);
           }
         }
       }
@@ -184,8 +220,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && empty($error)) {
   <?php else: ?>
     <form method="post">
       <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
-      <input type="text" name="username" required placeholder="Username">
-      <input type="password" name="password" required placeholder="Password">
+      <input type="text" name="username" required placeholder="Username" autocomplete="username">
+      <input type="password" name="password" required placeholder="Password" autocomplete="current-password">
       <button type="submit">Login</button>
     </form>
     <p><a href="forgot.php">Forgot Password?</a> | <a href="register.php">Register</a></p>

--- a/logout.php
+++ b/logout.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 
 session_destroy();
 header("Location: login.php");

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*.log
+!.gitignore

--- a/message-requests.php
+++ b/message-requests.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 
 $user_id = $_SESSION['user_id'];

--- a/message-thread.php
+++ b/message-thread.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/support.php';
 

--- a/messages.php
+++ b/messages.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 
 $user_id = $_SESSION['user_id'];

--- a/my-listings.php
+++ b/my-listings.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require_once __DIR__ . '/includes/authz.php';
 
 ensure_seller();

--- a/my-requests.php
+++ b/my-requests.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 
 $id = $_SESSION['user_id'];

--- a/notifications.php
+++ b/notifications.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require_once 'includes/notifications.php';
 
 $user_id = $_SESSION['user_id'];

--- a/order.php
+++ b/order.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/orders.php';
 
 $orderId = isset($_GET['id']) ? (int) $_GET['id'] : 0;

--- a/privacy.php
+++ b/privacy.php
@@ -1,4 +1,4 @@
-<?php require_once __DIR__ . '/includes/auth.php'; ?>
+<?php require_once __DIR__ . '/includes/require-auth.php'; ?>
 <?php require 'includes/layout.php'; ?>
   <meta charset="UTF-8">
   <title>Privacy Policy</title>

--- a/profile.php
+++ b/profile.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/totp.php';

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Disallow: /.git/
+Disallow: /vendor/
+Disallow: /node_modules/
+Disallow: /admin/
+Allow: /assets/

--- a/search.php
+++ b/search.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 
 if (!isset($db) || !($db instanceof mysqli)) {
     $db = require __DIR__ . '/includes/db.php';

--- a/sell-step.php
+++ b/sell-step.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 
 $category = $_GET['category'] ?? '';

--- a/sell.php
+++ b/sell.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require_once __DIR__ . '/includes/authz.php';
 require 'includes/db.php';
 require 'includes/csrf.php';

--- a/service-step.php
+++ b/service-step.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 
 // Service requests now have a dedicated step handler. Buy, sell and trade

--- a/service-wizard.php
+++ b/service-wizard.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 require 'includes/db.php';
 

--- a/services.php
+++ b/services.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 require 'includes/db.php';
 ?>

--- a/shipping.php
+++ b/shipping.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/shop-manager/index.php
+++ b/shop-manager/index.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../includes/shop_manager.php';

--- a/submit-request.php
+++ b/submit-request.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require_once 'mail.php';

--- a/success.php
+++ b/success.php
@@ -1,6 +1,6 @@
 <?php
 require __DIR__ . '/_debug_bootstrap.php';
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 ?>
 <?php require 'includes/layout.php'; ?>
   <title>Payment Success</title>

--- a/support.php
+++ b/support.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 require 'includes/support.php';
 

--- a/terms.php
+++ b/terms.php
@@ -1,4 +1,4 @@
-<?php require_once __DIR__ . '/includes/auth.php'; ?>
+<?php require_once __DIR__ . '/includes/require-auth.php'; ?>
 <?php require 'includes/layout.php'; ?>
   <meta charset="UTF-8">
   <title>Terms of Service</title>

--- a/trade-cancel.php
+++ b/trade-cancel.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/trade-fulfillment.php
+++ b/trade-fulfillment.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/notifications.php';

--- a/trade-listing-delete.php
+++ b/trade-listing-delete.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require_once __DIR__ . '/includes/authz.php';
 require 'includes/db.php';
 require 'includes/csrf.php';

--- a/trade-listing.php
+++ b/trade-listing.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/trade-listings.php
+++ b/trade-listings.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/user.php';
 require 'includes/csrf.php';

--- a/trade-offer-delete.php
+++ b/trade-offer-delete.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require_once __DIR__ . '/includes/authz.php';
 require 'includes/db.php';
 require 'includes/csrf.php';

--- a/trade-offer.php
+++ b/trade-offer.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/trade.php';

--- a/trade-step.php
+++ b/trade-step.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 
 $category = $_GET['category'] ?? '';

--- a/trade.php
+++ b/trade.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 require 'includes/trade.php';

--- a/update-request.php
+++ b/update-request.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 

--- a/view-profile.php
+++ b/view-profile.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/csrf.php';
 require 'includes/notifications.php';
 require 'includes/components.php';

--- a/vip.php
+++ b/vip.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/csrf.php';
 


### PR DESCRIPTION
## Summary
- add .htaccess rules and a PHP fallback to block sensitive paths while setting baseline security headers
- expose reusable auth helpers, convert entry points to a require-auth wrapper, and add centralized security header/no-store utilities
- harden login.php with cache controls, CSRF validation, session/IP throttling, and targeted security logging; document the changes and publish robots.txt guidance

## Testing
- php -l includes/auth.php
- php -l login.php
- php -l includes/security.php
- php -l includes/require-auth.php

------
https://chatgpt.com/codex/tasks/task_e_68d33fb32b90832b96d6ba9bfca087be