### PR TITLE
Add Square sync service and webhook handling

### DIFF
--- a/admin/health.php
+++ b/admin/health.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ * Discovery note: Admin area lacked a diagnostics view despite handling support, listings, and trades.
+ * Change: Added a Square Health stub that surfaces sync/webhook timestamps and recent errors for admins.
+ */
+require_once __DIR__ . '/../includes/require-auth.php';
+require_once __DIR__ . '/../includes/authz.php';
+require '../includes/db.php';
+require_once __DIR__ . '/../includes/square-migrations.php';
+
+ensure_admin('../dashboard.php');
+
+square_run_migrations($conn);
+
+$stateKey = 'square_core';
+$state = [
+    'last_synced_at' => null,
+    'last_webhook_at' => null,
+    'sync_direction' => 'pull',
+];
+
+if ($stmt = $conn->prepare('SELECT last_synced_at, last_webhook_at, sync_direction FROM square_sync_state WHERE setting_key = ? LIMIT 1')) {
+    $stmt->bind_param('s', $stateKey);
+    if ($stmt->execute() && ($result = $stmt->get_result())) {
+        if ($row = $result->fetch_assoc()) {
+            $state['last_synced_at'] = $row['last_synced_at'];
+            $state['last_webhook_at'] = $row['last_webhook_at'];
+            $state['sync_direction'] = $row['sync_direction'] ?: 'pull';
+        }
+        $result->free();
+    }
+    $stmt->close();
+}
+
+$errors = [];
+if ($stmt = $conn->prepare('SELECT error_code, message, context, created_at FROM square_sync_errors ORDER BY created_at DESC LIMIT 5')) {
+    if ($stmt->execute() && ($result = $stmt->get_result())) {
+        while ($row = $result->fetch_assoc()) {
+            $context = $row['context'];
+            $decoded = null;
+            if (is_string($context) && $context !== '') {
+                $decoded = json_decode($context, true);
+                if (json_last_error() === JSON_ERROR_NONE && $decoded !== null) {
+                    $context = json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                }
+            }
+
+            $errors[] = [
+                'error_code' => $row['error_code'],
+                'message' => $row['message'],
+                'context' => $context,
+                'created_at' => $row['created_at'],
+            ];
+        }
+        $result->free();
+    }
+    $stmt->close();
+}
+
+$lastSync = $state['last_synced_at'] ? date('Y-m-d H:i:s', strtotime((string) $state['last_synced_at'])) : 'Never';
+$lastWebhook = $state['last_webhook_at'] ? date('Y-m-d H:i:s', strtotime((string) $state['last_webhook_at'])) : 'Never';
+$direction = $state['sync_direction'] ?: 'pull';
+?>
+<?php require '../includes/layout.php'; ?>
+  <title>Square Health</title>
+  <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+  <?php include '../includes/header.php'; ?>
+  <main class="admin-health">
+    <h2>Square Integration Health</h2>
+    <section class="health-card">
+      <h3>Sync Overview</h3>
+      <ul>
+        <li><strong>Sync Direction:</strong> <?= htmlspecialchars($direction, ENT_QUOTES, 'UTF-8'); ?></li>
+        <li><strong>Last Sync:</strong> <?= htmlspecialchars($lastSync, ENT_QUOTES, 'UTF-8'); ?></li>
+        <li><strong>Last Webhook:</strong> <?= htmlspecialchars($lastWebhook, ENT_QUOTES, 'UTF-8'); ?></li>
+      </ul>
+    </section>
+    <section class="health-card">
+      <h3>Recent Errors</h3>
+      <?php if (!$errors): ?>
+        <p>No Square errors recorded.</p>
+      <?php else: ?>
+        <ol class="health-errors">
+          <?php foreach ($errors as $error): ?>
+            <li>
+              <div><strong><?= htmlspecialchars($error['created_at'], ENT_QUOTES, 'UTF-8'); ?></strong></div>
+              <?php if (!empty($error['error_code'])): ?>
+                <div>Code: <code><?= htmlspecialchars($error['error_code'], ENT_QUOTES, 'UTF-8'); ?></code></div>
+              <?php endif; ?>
+              <div><?= nl2br(htmlspecialchars($error['message'], ENT_QUOTES, 'UTF-8')); ?></div>
+              <?php if (!empty($error['context'])): ?>
+                <pre><?= htmlspecialchars((string) $error['context'], ENT_QUOTES, 'UTF-8'); ?></pre>
+              <?php endif; ?>
+            </li>
+          <?php endforeach; ?>
+        </ol>
+      <?php endif; ?>
+    </section>
+  </main>
+  <?php include '../includes/footer.php'; ?>
+</body>
+</html>

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,10 +1,17 @@
 <?php
+/*
+ * Discovery note: Admin dashboard organizes listings, trades, and system utilities but lacked status visibility.
+ * Change: Extended navigation so the experimental manager workspace only appears when the rollout flag is enabled.
+ */
 require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';
 require '../includes/user.php';
+$config = require __DIR__ . '/../config.php';
 
 ensure_admin('../dashboard.php');
+
+$managerEnabled = !empty($config['SHOP_MANAGER_V1_ENABLED']);
 
 $stmt = $conn->query("SELECT r.id, u.id AS user_id, u.username, r.category, r.issue, r.created_at, r.status
                       FROM service_requests r
@@ -25,6 +32,9 @@ $requests = $stmt->fetch_all(MYSQLI_ASSOC);
       <h3>Listings</h3>
       <ul class="nav-links">
         <li><a class="btn" href="listings.php">Review Listings</a></li>
+        <?php if ($managerEnabled): ?>
+          <li><a class="btn" href="manager.php">Shop Manager V1</a></li>
+        <?php endif; ?>
       </ul>
     </div>
     <div class="nav-section">
@@ -41,6 +51,7 @@ $requests = $stmt->fetch_all(MYSQLI_ASSOC);
         <li><a class="btn" href="theme.php">Vaporwave Theme Settings</a></li>
         <li><a class="btn" href="toolbox.php">Manage Toolbox</a></li>
         <li><a class="btn" href="support.php">Support Tickets</a></li>
+        <li><a class="btn" href="health.php">Square Health</a></li>
       </ul>
     </div>
   </div>

--- a/admin/manager.php
+++ b/admin/manager.php
@@ -1,0 +1,940 @@
+<?php
+/*
+ * Discovery note: Admin tooling was fragmented across products, listings, and orders without a single control surface.
+ * Change: Added a feature-gated Shop Manager V1 workspace with tabbed workflows for catalog, listings, inventory, orders, and reporting.
+ */
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/require-auth.php';
+require_once __DIR__ . '/../includes/authz.php';
+require_once __DIR__ . '/../includes/csrf.php';
+require_once __DIR__ . '/../includes/orders.php';
+require_once __DIR__ . '/../includes/store.php';
+require_once __DIR__ . '/../includes/repositories/ChangeRequestsService.php';
+require_once __DIR__ . '/../includes/repositories/ListingsRepo.php';
+require_once __DIR__ . '/../includes/repositories/InventoryService.php';
+require_once __DIR__ . '/../includes/repositories/OrdersService.php';
+
+$config = require __DIR__ . '/../config.php';
+
+if (empty($config['SHOP_MANAGER_V1_ENABLED'])) {
+    http_response_code(404);
+    echo 'The Shop Manager preview is not currently enabled.';
+    exit;
+}
+
+ensure_admin_or_official('../dashboard.php');
+
+/** @var mysqli|null $conn */
+if (!isset($conn) || !($conn instanceof mysqli)) {
+    $conn = require __DIR__ . '/../includes/db.php';
+}
+
+$viewerId = (int) ($_SESSION['user_id'] ?? 0);
+$isAdmin = authz_has_role('admin');
+$isOfficial = authz_has_role('skuze_official');
+
+$changeRequests = new ChangeRequestsService($conn);
+$listingsRepo = new ListingsRepo($conn, $changeRequests);
+$inventoryService = new InventoryService($conn);
+$ordersService = new OrdersService($conn);
+
+$tabs = [
+    'products' => 'Products',
+    'listings' => 'Listings',
+    'inventory' => 'Inventory',
+    'orders' => 'Orders',
+    'shipping' => 'Shipping',
+    'sync' => 'Sync',
+    'reports' => 'Reports',
+];
+
+if (!function_exists('admin_manager_resolve_tab')) {
+    function admin_manager_resolve_tab(string $requested, array $tabs): string
+    {
+        $requested = strtolower(trim($requested));
+        if ($requested !== '' && array_key_exists($requested, $tabs)) {
+            return $requested;
+        }
+
+        return 'products';
+    }
+}
+
+if (!function_exists('admin_manager_flash')) {
+    function admin_manager_flash(string $type, string $message): void
+    {
+        if (!isset($_SESSION['admin_manager_flash']) || !is_array($_SESSION['admin_manager_flash'])) {
+            $_SESSION['admin_manager_flash'] = [];
+        }
+
+        $_SESSION['admin_manager_flash'][] = [
+            'type' => $type,
+            'message' => $message,
+        ];
+    }
+}
+
+if (!function_exists('admin_manager_consume_flash')) {
+    /**
+     * @return array<int, array{type: string, message: string}>
+     */
+    function admin_manager_consume_flash(): array
+    {
+        if (!isset($_SESSION['admin_manager_flash']) || !is_array($_SESSION['admin_manager_flash'])) {
+            return [];
+        }
+
+        $messages = array_values(array_filter(array_map(
+            static function ($entry): ?array {
+                if (!is_array($entry) || !isset($entry['type'], $entry['message'])) {
+                    return null;
+                }
+
+                return [
+                    'type' => (string) $entry['type'],
+                    'message' => (string) $entry['message'],
+                ];
+            },
+            $_SESSION['admin_manager_flash']
+        )));
+
+        unset($_SESSION['admin_manager_flash']);
+
+        return $messages;
+    }
+}
+
+if (!function_exists('admin_manager_next_status')) {
+    function admin_manager_next_status(string $status): ?string
+    {
+        $status = strtolower(trim($status));
+        if ($status === 'pending') {
+            $status = 'new';
+        }
+
+        $map = [
+            'new' => 'paid',
+            'paid' => 'packing',
+            'packing' => 'shipped',
+            'shipped' => 'delivered',
+            'delivered' => 'completed',
+        ];
+
+        return $map[$status] ?? null;
+    }
+}
+
+$requestedTab = $_SERVER['REQUEST_METHOD'] === 'POST'
+    ? (string) ($_POST['tab'] ?? 'products')
+    : (string) ($_GET['tab'] ?? 'products');
+$activeTab = admin_manager_resolve_tab($requestedTab, $tabs);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $redirectTab = admin_manager_resolve_tab((string) ($_POST['tab'] ?? $activeTab), $tabs);
+    $token = (string) ($_POST['csrf_token'] ?? '');
+    if (!validate_token($token)) {
+        admin_manager_flash('error', 'Invalid request token.');
+    } else {
+        $action = (string) ($_POST['manager_action'] ?? '');
+        try {
+            switch ($action) {
+                case 'update_product':
+                    $sku = strtoupper(trim((string) ($_POST['sku'] ?? '')));
+                    $title = trim((string) ($_POST['title'] ?? ''));
+                    $priceInput = trim((string) ($_POST['price'] ?? '0'));
+                    $stock = max(0, (int) ($_POST['stock'] ?? 0));
+                    $officialFlag = !empty($_POST['is_skuze_official']) ? 1 : 0;
+                    $productFlag = !empty($_POST['is_skuze_product']) ? 1 : 0;
+
+                    if ($sku === '' || $title === '') {
+                        throw new RuntimeException('SKU and title are required.');
+                    }
+
+                    if ($priceInput === '') {
+                        $priceInput = '0';
+                    }
+
+                    if (!preg_match('/^\d+(?:\.\d{1,2})?$/', $priceInput)) {
+                        throw new RuntimeException('Prices must be numeric with up to two decimals.');
+                    }
+
+                    $price = number_format((float) $priceInput, 2, '.', '');
+
+                    $conn->begin_transaction();
+                    $stmt = $conn->prepare(
+                        'UPDATE products SET title = ?, price = ?, stock = ?, '
+                        . 'quantity = CASE WHEN quantity IS NULL THEN NULL ELSE ? END, '
+                        . 'is_skuze_official = ?, is_skuze_product = ?, is_official = ? '
+                        . 'WHERE sku = ?'
+                    );
+                    if ($stmt === false) {
+                        throw new RuntimeException('Unable to prepare product update.');
+                    }
+
+                    $quantityMirror = $stock;
+                    $stmt->bind_param(
+                        'sdiiiiis',
+                        $title,
+                        $price,
+                        $stock,
+                        $quantityMirror,
+                        $officialFlag,
+                        $productFlag,
+                        $officialFlag,
+                        $sku
+                    );
+                    if (!$stmt->execute()) {
+                        throw new RuntimeException('Failed to update product: ' . $stmt->error);
+                    }
+                    $stmt->close();
+
+                    $listingFlag = ($officialFlag || $productFlag) ? 1 : 0;
+                    $link = $conn->prepare('UPDATE listings SET is_official_listing = ? WHERE product_sku = ?');
+                    if ($link !== false) {
+                        $link->bind_param('is', $listingFlag, $sku);
+                        $link->execute();
+                        $link->close();
+                    }
+
+                    $conn->commit();
+                    admin_manager_flash('success', 'Product ' . $sku . ' updated.');
+                    break;
+
+                case 'update_listing_details':
+                    $listingId = (int) ($_POST['listing_id'] ?? 0);
+                    $title = trim((string) ($_POST['title'] ?? ''));
+                    $priceInput = trim((string) ($_POST['price'] ?? ''));
+                    $quantityInput = trim((string) ($_POST['quantity'] ?? ''));
+
+                    if ($listingId <= 0) {
+                        throw new RuntimeException('Invalid listing specified.');
+                    }
+
+                    if ($priceInput !== '' && !preg_match('/^\d+(?:\.\d{1,2})?$/', $priceInput)) {
+                        throw new RuntimeException('Listing price must be numeric with up to two decimals.');
+                    }
+
+                    if ($quantityInput !== '' && !preg_match('/^\d+$/', $quantityInput)) {
+                        throw new RuntimeException('Quantity must be a whole number.');
+                    }
+
+                    $payload = [
+                        'title' => $title,
+                        'price' => $priceInput,
+                        'quantity' => $quantityInput,
+                    ];
+
+                    $result = $listingsRepo->updateDetails(
+                        $listingId,
+                        $viewerId,
+                        $payload,
+                        $isAdmin,
+                        $isOfficial
+                    );
+
+                    if (!empty($result['requires_review'])) {
+                        admin_manager_flash('success', 'Change request submitted for moderation.');
+                    } elseif (!empty($result['changed'])) {
+                        admin_manager_flash('success', 'Listing updated.');
+                    } else {
+                        admin_manager_flash('info', 'No changes detected for the listing.');
+                    }
+                    break;
+
+                case 'approve_listing_change':
+                    $requestId = (int) ($_POST['request_id'] ?? 0);
+                    if ($requestId <= 0) {
+                        throw new RuntimeException('Missing change request id.');
+                    }
+                    $listingsRepo->approveChangeRequest($requestId, $viewerId);
+                    admin_manager_flash('success', 'Change request approved and applied.');
+                    break;
+
+                case 'reject_listing_change':
+                    $requestId = (int) ($_POST['request_id'] ?? 0);
+                    if ($requestId <= 0) {
+                        throw new RuntimeException('Missing change request id.');
+                    }
+                    $listingId = (int) ($_POST['listing_id'] ?? 0);
+                    if ($listingId > 0) {
+                        $changeRequests->markSingleRequest($requestId, 'rejected', $viewerId, null, 'Rejected in manager workspace');
+                    } else {
+                        $changeRequests->markSingleRequest($requestId, 'rejected', $viewerId);
+                    }
+                    admin_manager_flash('success', 'Change request rejected.');
+                    break;
+
+                case 'adjust_stock':
+                    $sku = strtoupper(trim((string) ($_POST['sku'] ?? '')));
+                    $deltaInput = trim((string) ($_POST['delta'] ?? '0'));
+                    $thresholdInput = trim((string) ($_POST['reorder_threshold'] ?? ''));
+
+                    if ($sku === '') {
+                        throw new RuntimeException('A SKU is required for stock adjustments.');
+                    }
+
+                    if (!preg_match('/^-?\d+$/', $deltaInput)) {
+                        throw new RuntimeException('Stock adjustments must be whole numbers.');
+                    }
+                    $delta = (int) $deltaInput;
+
+                    $threshold = null;
+                    if ($thresholdInput !== '') {
+                        if (!preg_match('/^\d+$/', $thresholdInput)) {
+                            throw new RuntimeException('Reorder threshold must be zero or a positive whole number.');
+                        }
+                        $threshold = (int) $thresholdInput;
+                    }
+
+                    $state = $inventoryService->adjustProductStock(
+                        $sku,
+                        $delta,
+                        $viewerId,
+                        $threshold,
+                        $isAdmin,
+                        $isOfficial
+                    );
+
+                    admin_manager_flash(
+                        'success',
+                        sprintf(
+                            'Stock for %s adjusted by %d. New stock: %d.',
+                            $state['sku'],
+                            $delta,
+                            $state['stock']
+                        )
+                    );
+                    break;
+
+                case 'advance_order':
+                    $orderId = (int) ($_POST['order_id'] ?? 0);
+                    $targetStatus = (string) ($_POST['status'] ?? '');
+                    if ($orderId <= 0 || $targetStatus === '') {
+                        throw new RuntimeException('Invalid order advance request.');
+                    }
+                    $ordersService->updateStatus($orderId, $targetStatus, $viewerId, $isAdmin, $isOfficial);
+                    admin_manager_flash('success', 'Order #' . $orderId . ' moved to ' . ucfirst($targetStatus) . '.');
+                    break;
+
+                case 'update_tracking':
+                    $orderId = (int) ($_POST['order_id'] ?? 0);
+                    $tracking = trim((string) ($_POST['tracking_number'] ?? ''));
+                    if ($orderId <= 0) {
+                        throw new RuntimeException('Invalid order for tracking update.');
+                    }
+                    $ordersService->updateTracking($orderId, $tracking === '' ? null : $tracking, $viewerId, $isAdmin, $isOfficial);
+                    admin_manager_flash('success', 'Tracking updated for order #' . $orderId . '.');
+                    break;
+
+                default:
+                    admin_manager_flash('error', 'Unsupported action requested.');
+                    break;
+            }
+        } catch (Throwable $e) {
+            admin_manager_flash('error', $e->getMessage());
+        }
+    }
+
+    $query = ['tab' => $redirectTab];
+    header('Location: manager.php?' . http_build_query($query));
+    exit;
+}
+
+$csrfToken = generate_token();
+$flashMessages = admin_manager_consume_flash();
+
+$products = [];
+if ($result = $conn->query(
+    'SELECT sku, title, price, stock, quantity, reorder_threshold, '
+    . 'is_skuze_official, is_skuze_product, is_official '
+    . 'FROM products ORDER BY created_at DESC LIMIT 100'
+)) {
+    while ($row = $result->fetch_assoc()) {
+        $products[] = $row;
+    }
+    $result->close();
+}
+
+$listings = [];
+if ($result = $conn->query(
+    "SELECT l.id, l.title, l.price, l.quantity, l.status, l.is_official_listing, "
+    . "u.username AS owner_username, "
+    . "(SELECT COUNT(*) FROM listing_change_requests r WHERE r.listing_id = l.id AND r.status = 'pending') AS pending_requests "
+    . "FROM listings l JOIN users u ON l.owner_id = u.id "
+    . "WHERE l.status IN ('draft','pending','approved','live') "
+    . "ORDER BY l.updated_at DESC LIMIT 100"
+)) {
+    while ($row = $result->fetch_assoc()) {
+        $listings[] = $row;
+    }
+    $result->close();
+}
+
+$pendingChanges = [];
+if ($result = $conn->query(
+    "SELECT r.id, r.listing_id, r.change_summary, r.payload, r.created_at, "
+    . "u.username AS requester_username, l.title AS listing_title, l.status AS listing_status "
+    . "FROM listing_change_requests r "
+    . "JOIN listings l ON r.listing_id = l.id "
+    . "JOIN users u ON r.requester_id = u.id "
+    . "WHERE r.status = 'pending' ORDER BY r.created_at DESC LIMIT 50"
+)) {
+    while ($row = $result->fetch_assoc()) {
+        $payload = $row['payload'];
+        $decoded = null;
+        if ($payload !== null && $payload !== '') {
+            $decoded = json_decode((string) $payload, true);
+            if (!is_array($decoded)) {
+                $decoded = null;
+            }
+        }
+        $row['payload'] = $decoded;
+        $pendingChanges[] = $row;
+    }
+    $result->close();
+}
+
+$inventoryLedger = [];
+if ($result = $conn->query(
+    'SELECT it.product_sku, it.owner_id, it.transaction_type, it.quantity_change, '
+    . 'it.quantity_before, it.quantity_after, it.reference_type, it.reference_id, '
+    . 'it.metadata, it.created_at, u.username AS owner_username '
+    . 'FROM inventory_transactions it '
+    . 'LEFT JOIN users u ON it.owner_id = u.id '
+    . 'ORDER BY it.created_at DESC LIMIT 50'
+)) {
+    while ($row = $result->fetch_assoc()) {
+        $metadata = $row['metadata'];
+        $decoded = null;
+        if ($metadata !== null && $metadata !== '') {
+            $decoded = json_decode((string) $metadata, true);
+            if (!is_array($decoded)) {
+                $decoded = null;
+            }
+        }
+        $row['metadata'] = $decoded;
+        $inventoryLedger[] = $row;
+    }
+    $result->close();
+}
+
+$orders = array_slice(fetch_orders_for_admin($conn, null, $viewerId), 0, 25);
+
+$shippingQueue = array_values(array_filter($orders, static function (array $order): bool {
+    $status = strtolower((string) ($order['shipping_status'] ?? ''));
+    return in_array($status, ['paid', 'packing', 'shipped'], true);
+}));
+
+$syncState = [
+    'enabled' => !empty($config['SQUARE_SYNC_ENABLED']),
+    'direction' => $config['SQUARE_SYNC_DIRECTION'] ?? 'pull',
+    'orders_flag' => !empty($config['USE_SQUARE_ORDERS']),
+];
+
+$reports = [
+    'total_products' => 0,
+    'official_products' => 0,
+    'pending_listing_requests' => count($pendingChanges),
+    'open_orders' => count(array_filter($orders, static function (array $order): bool {
+        $status = strtolower((string) ($order['shipping_status'] ?? ''));
+        return !in_array($status, ['completed', 'cancelled'], true);
+    })),
+];
+
+if ($result = $conn->query('SELECT COUNT(*) AS total, SUM(CASE WHEN is_skuze_official = 1 OR is_official = 1 THEN 1 ELSE 0 END) AS official FROM products')) {
+    if ($row = $result->fetch_assoc()) {
+        $reports['total_products'] = (int) ($row['total'] ?? 0);
+        $reports['official_products'] = (int) ($row['official'] ?? 0);
+    }
+    $result->close();
+}
+
+?>
+<?php require __DIR__ . '/../includes/layout.php'; ?>
+  <title>Shop Manager V1</title>
+  <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+  <?php include __DIR__ . '/../includes/header.php'; ?>
+  <div class="page-container store">
+    <header class="store__header">
+      <div>
+        <h1>Shop Manager V1</h1>
+        <p class="store__subtitle">Preview workspace for catalog, listings, inventory, and fulfillment oversight.</p>
+      </div>
+    </header>
+
+    <nav class="store__tabs" role="tablist" aria-label="Manager sections">
+      <?php foreach ($tabs as $key => $label): ?>
+        <?php $isActive = $key === $activeTab; ?>
+        <button
+          type="button"
+          class="store__tab<?= $isActive ? ' is-active' : ''; ?>"
+          role="tab"
+          aria-selected="<?= $isActive ? 'true' : 'false'; ?>"
+          aria-controls="manager-panel-<?= htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>"
+          onclick="window.location.href='manager.php?tab=<?= htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>'"
+        >
+          <?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?>
+        </button>
+      <?php endforeach; ?>
+    </nav>
+
+    <?php if ($flashMessages): ?>
+      <div class="store__alert" role="status">
+        <?php foreach ($flashMessages as $message): ?>
+          <div class="alert <?= htmlspecialchars($message['type'], ENT_QUOTES, 'UTF-8'); ?>">
+            <?= htmlspecialchars($message['message'], ENT_QUOTES, 'UTF-8'); ?>
+          </div>
+        <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+
+    <section
+      id="manager-panel-products"
+      class="store__panel<?= $activeTab === 'products' ? ' is-active' : ''; ?>"
+      role="tabpanel"
+      aria-labelledby="manager-tab-products"
+      <?= $activeTab === 'products' ? '' : 'hidden'; ?>
+    >
+      <h2>Products</h2>
+      <p>Review catalog entries, adjust pricing, and toggle official product flags.</p>
+      <?php if ($products): ?>
+        <div class="table-wrapper">
+          <table class="store-table">
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Title</th>
+                <th>Price</th>
+                <th>Stock</th>
+                <th>Flags</th>
+                <th class="store-table__actions">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($products as $product): ?>
+                <tr>
+                  <th scope="row"><?= htmlspecialchars($product['sku'], ENT_QUOTES, 'UTF-8'); ?></th>
+                  <td>
+                    <?= htmlspecialchars($product['title'], ENT_QUOTES, 'UTF-8'); ?>
+                    <?php if (!empty($product['is_skuze_official']) || !empty($product['is_official'])): ?>
+                      <span class="badge badge-official">Official</span>
+                    <?php endif; ?>
+                    <?php if (!empty($product['is_skuze_product'])): ?>
+                      <span class="badge badge-product">Product</span>
+                    <?php endif; ?>
+                  </td>
+                  <td>$<?= htmlspecialchars(number_format((float) $product['price'], 2), ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= (int) $product['stock']; ?></td>
+                  <td>
+                    Official: <?= !empty($product['is_skuze_official']) || !empty($product['is_official']) ? 'Yes' : 'No'; ?><br>
+                    Product: <?= !empty($product['is_skuze_product']) ? 'Yes' : 'No'; ?>
+                  </td>
+                  <td>
+                    <form method="post" class="inline-form">
+                      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                      <input type="hidden" name="manager_action" value="update_product">
+                      <input type="hidden" name="tab" value="products">
+                      <input type="hidden" name="sku" value="<?= htmlspecialchars($product['sku'], ENT_QUOTES, 'UTF-8'); ?>">
+                      <div class="form-grid">
+                        <label>Title
+                          <input type="text" name="title" value="<?= htmlspecialchars($product['title'], ENT_QUOTES, 'UTF-8'); ?>">
+                        </label>
+                        <label>Price
+                          <input type="text" name="price" value="<?= htmlspecialchars(number_format((float) $product['price'], 2, '.', ''), ENT_QUOTES, 'UTF-8'); ?>">
+                        </label>
+                        <label>Stock
+                          <input type="number" name="stock" value="<?= (int) $product['stock']; ?>" min="0">
+                        </label>
+                        <label class="checkbox">
+                          <input type="checkbox" name="is_skuze_official" value="1" <?= !empty($product['is_skuze_official']) || !empty($product['is_official']) ? 'checked' : ''; ?>>
+                          SkuzE Official
+                        </label>
+                        <label class="checkbox">
+                          <input type="checkbox" name="is_skuze_product" value="1" <?= !empty($product['is_skuze_product']) ? 'checked' : ''; ?>>
+                          SkuzE Product
+                        </label>
+                      </div>
+                      <button type="submit" class="btn">Save</button>
+                    </form>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php else: ?>
+        <p>No products found.</p>
+      <?php endif; ?>
+    </section>
+
+    <section
+      id="manager-panel-listings"
+      class="store__panel<?= $activeTab === 'listings' ? ' is-active' : ''; ?>"
+      role="tabpanel"
+      aria-labelledby="manager-tab-listings"
+      <?= $activeTab === 'listings' ? '' : 'hidden'; ?>
+    >
+      <h2>Listings</h2>
+      <p>Monitor listing state changes and review seller-submitted updates.</p>
+      <?php if ($listings): ?>
+        <div class="table-wrapper">
+          <table class="store-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Title</th>
+                <th>Status</th>
+                <th>Quantity</th>
+                <th>Owner</th>
+                <th class="store-table__actions">Edit</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($listings as $listing): ?>
+                <tr>
+                  <th scope="row">#<?= (int) $listing['id']; ?></th>
+                  <td>
+                    <?= htmlspecialchars($listing['title'], ENT_QUOTES, 'UTF-8'); ?>
+                    <?php if (!empty($listing['is_official_listing'])): ?>
+                      <span class="badge badge-official">Official</span>
+                    <?php endif; ?>
+                    <?php if ((int) $listing['pending_requests'] > 0): ?>
+                      <div class="badge badge-warning">Pending approval</div>
+                    <?php endif; ?>
+                  </td>
+                  <td><?= htmlspecialchars(ucfirst((string) $listing['status']), ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= $listing['quantity'] !== null ? (int) $listing['quantity'] : '—'; ?></td>
+                  <td><?= htmlspecialchars((string) $listing['owner_username'], ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td>
+                    <form method="post" class="inline-form">
+                      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                      <input type="hidden" name="manager_action" value="update_listing_details">
+                      <input type="hidden" name="tab" value="listings">
+                      <input type="hidden" name="listing_id" value="<?= (int) $listing['id']; ?>">
+                      <div class="form-grid">
+                        <label>Title
+                          <input type="text" name="title" value="<?= htmlspecialchars($listing['title'], ENT_QUOTES, 'UTF-8'); ?>">
+                        </label>
+                        <label>Price
+                          <input type="text" name="price" value="<?= htmlspecialchars(number_format((float) $listing['price'], 2, '.', ''), ENT_QUOTES, 'UTF-8'); ?>">
+                        </label>
+                        <label>Quantity
+                          <input type="number" name="quantity" value="<?= $listing['quantity'] !== null ? (int) $listing['quantity'] : 0; ?>" min="0">
+                        </label>
+                      </div>
+                      <button type="submit" class="btn">Save</button>
+                    </form>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php else: ?>
+        <p>No listings available for review.</p>
+      <?php endif; ?>
+
+      <h3>Pending change requests</h3>
+      <?php if ($pendingChanges): ?>
+        <div class="table-wrapper">
+          <table class="store-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Listing</th>
+                <th>Requested by</th>
+                <th>Submitted</th>
+                <th>Payload</th>
+                <th class="store-table__actions">Moderation</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($pendingChanges as $request): ?>
+                <tr>
+                  <th scope="row">#<?= (int) $request['id']; ?></th>
+                  <td>
+                    <?= htmlspecialchars($request['listing_title'], ENT_QUOTES, 'UTF-8'); ?><br>
+                    <small>Status: <?= htmlspecialchars($request['listing_status'], ENT_QUOTES, 'UTF-8'); ?></small>
+                  </td>
+                  <td><?= htmlspecialchars($request['requester_username'], ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= htmlspecialchars($request['created_at'], ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td>
+                    <?php if (is_array($request['payload'])): ?>
+                      <ul>
+                        <?php foreach ($request['payload'] as $field => $value): ?>
+                          <li><strong><?= htmlspecialchars($field, ENT_QUOTES, 'UTF-8'); ?>:</strong> <?= htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8'); ?></li>
+                        <?php endforeach; ?>
+                      </ul>
+                    <?php else: ?>
+                      <?= htmlspecialchars($request['change_summary'] ?? '—', ENT_QUOTES, 'UTF-8'); ?>
+                    <?php endif; ?>
+                  </td>
+                  <td>
+                    <form method="post" class="inline-form" style="margin-bottom:0.5rem;">
+                      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                      <input type="hidden" name="manager_action" value="approve_listing_change">
+                      <input type="hidden" name="tab" value="listings">
+                      <input type="hidden" name="request_id" value="<?= (int) $request['id']; ?>">
+                      <button type="submit" class="btn">Approve</button>
+                    </form>
+                    <form method="post" class="inline-form">
+                      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                      <input type="hidden" name="manager_action" value="reject_listing_change">
+                      <input type="hidden" name="tab" value="listings">
+                      <input type="hidden" name="request_id" value="<?= (int) $request['id']; ?>">
+                      <input type="hidden" name="listing_id" value="<?= (int) $request['listing_id']; ?>">
+                      <button type="submit" class="btn btn-secondary">Reject</button>
+                    </form>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php else: ?>
+        <p>No pending change requests.</p>
+      <?php endif; ?>
+    </section>
+
+    <section
+      id="manager-panel-inventory"
+      class="store__panel<?= $activeTab === 'inventory' ? ' is-active' : ''; ?>"
+      role="tabpanel"
+      aria-labelledby="manager-tab-inventory"
+      <?= $activeTab === 'inventory' ? '' : 'hidden'; ?>
+    >
+      <h2>Inventory</h2>
+      <p>Ledger of recent stock adjustments with manual adjustment controls.</p>
+
+      <form method="post" class="inline-form">
+        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="hidden" name="manager_action" value="adjust_stock">
+        <input type="hidden" name="tab" value="inventory">
+        <div class="form-grid">
+          <label>SKU
+            <input type="text" name="sku" required>
+          </label>
+          <label>Adjust by
+            <input type="number" name="delta" value="0" step="1">
+          </label>
+          <label>Reorder threshold
+            <input type="number" name="reorder_threshold" min="0" step="1">
+          </label>
+        </div>
+        <button type="submit" class="btn">Apply adjustment</button>
+      </form>
+
+      <?php if ($inventoryLedger): ?>
+        <div class="table-wrapper" style="margin-top:1rem;">
+          <table class="store-table">
+            <thead>
+              <tr>
+                <th>Created</th>
+                <th>SKU</th>
+                <th>Owner</th>
+                <th>Type</th>
+                <th>Delta</th>
+                <th>Before → After</th>
+                <th>Reference</th>
+                <th>Metadata</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($inventoryLedger as $entry): ?>
+                <tr>
+                  <td><?= htmlspecialchars($entry['created_at'], ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= htmlspecialchars((string) $entry['product_sku'], ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= htmlspecialchars($entry['owner_username'] ?? ('#' . $entry['owner_id']), ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= htmlspecialchars($entry['transaction_type'], ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= (int) $entry['quantity_change']; ?></td>
+                  <td><?= $entry['quantity_before'] ?? '—'; ?> → <?= $entry['quantity_after'] ?? '—'; ?></td>
+                  <td>
+                    <?php if (!empty($entry['reference_type'])): ?>
+                      <?= htmlspecialchars($entry['reference_type'], ENT_QUOTES, 'UTF-8'); ?> #<?= htmlspecialchars((string) $entry['reference_id'], ENT_QUOTES, 'UTF-8'); ?>
+                    <?php else: ?>
+                      —
+                    <?php endif; ?>
+                  </td>
+                  <td>
+                    <?php if (is_array($entry['metadata'])): ?>
+                      <code><?= htmlspecialchars(json_encode($entry['metadata']), ENT_QUOTES, 'UTF-8'); ?></code>
+                    <?php else: ?>
+                      —
+                    <?php endif; ?>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php else: ?>
+        <p>No inventory transactions recorded yet.</p>
+      <?php endif; ?>
+    </section>
+
+    <section
+      id="manager-panel-orders"
+      class="store__panel<?= $activeTab === 'orders' ? ' is-active' : ''; ?>"
+      role="tabpanel"
+      aria-labelledby="manager-tab-orders"
+      <?= $activeTab === 'orders' ? '' : 'hidden'; ?>
+    >
+      <h2>Orders</h2>
+      <p>Promote orders through the lifecycle from new to completed. Refund support is coming soon.</p>
+      <?php if ($orders): ?>
+        <div class="table-wrapper">
+          <table class="store-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Product</th>
+                <th>Payment</th>
+                <th>Status</th>
+                <th>Buyer</th>
+                <th>Seller</th>
+                <th class="store-table__actions">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($orders as $order): ?>
+                <?php
+                  $status = strtolower((string) ($order['shipping_status'] ?? 'new'));
+                  if ($status === 'pending') {
+                      $status = 'new';
+                  }
+                  $nextStatus = admin_manager_next_status($status);
+                  $paymentStatus = strtolower((string) ($order['payment']['status'] ?? 'pending'));
+                ?>
+                <tr>
+                  <th scope="row">#<?= (int) $order['id']; ?></th>
+                  <td><?= htmlspecialchars($order['product']['title'] ?: $order['listing']['title'], ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= htmlspecialchars(ucfirst($paymentStatus), ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= htmlspecialchars(ucfirst($status), ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= htmlspecialchars($order['buyer']['username'] ?? '—', ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= htmlspecialchars($order['listing']['owner_username'] ?? '—', ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td>
+                    <?php if ($nextStatus): ?>
+                      <form method="post" class="inline-form" style="margin-bottom:0.5rem;">
+                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                        <input type="hidden" name="manager_action" value="advance_order">
+                        <input type="hidden" name="tab" value="orders">
+                        <input type="hidden" name="order_id" value="<?= (int) $order['id']; ?>">
+                        <input type="hidden" name="status" value="<?= htmlspecialchars($nextStatus, ENT_QUOTES, 'UTF-8'); ?>">
+                        <button type="submit" class="btn">Advance to <?= htmlspecialchars(ucfirst($nextStatus), ENT_QUOTES, 'UTF-8'); ?></button>
+                      </form>
+                    <?php endif; ?>
+                    <button type="button" class="btn btn-secondary" disabled title="Refund tooling is coming soon">Refund (coming soon)</button>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php else: ?>
+        <p>No orders found.</p>
+      <?php endif; ?>
+    </section>
+
+    <section
+      id="manager-panel-shipping"
+      class="store__panel<?= $activeTab === 'shipping' ? ' is-active' : ''; ?>"
+      role="tabpanel"
+      aria-labelledby="manager-tab-shipping"
+      <?= $activeTab === 'shipping' ? '' : 'hidden'; ?>
+    >
+      <h2>Shipping</h2>
+      <p>Track fulfillments currently in motion and update tracking numbers as shipments go out.</p>
+      <?php if ($shippingQueue): ?>
+        <div class="table-wrapper">
+          <table class="store-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Listing</th>
+                <th>Status</th>
+                <th>Tracking</th>
+                <th class="store-table__actions">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($shippingQueue as $order): ?>
+                <?php $status = strtolower((string) ($order['shipping_status'] ?? 'new')); ?>
+                <tr>
+                  <th scope="row">#<?= (int) $order['id']; ?></th>
+                  <td><?= htmlspecialchars($order['listing']['title'], ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= htmlspecialchars(ucfirst($status), ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td><?= htmlspecialchars($order['tracking_number'] ?? '—', ENT_QUOTES, 'UTF-8'); ?></td>
+                  <td>
+                    <form method="post" class="inline-form">
+                      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+                      <input type="hidden" name="manager_action" value="update_tracking">
+                      <input type="hidden" name="tab" value="shipping">
+                      <input type="hidden" name="order_id" value="<?= (int) $order['id']; ?>">
+                      <label class="sr-only" for="tracking-<?= (int) $order['id']; ?>">Tracking number</label>
+                      <input id="tracking-<?= (int) $order['id']; ?>" type="text" name="tracking_number" value="<?= htmlspecialchars($order['tracking_number'] ?? '', ENT_QUOTES, 'UTF-8'); ?>" placeholder="Tracking number">
+                      <button type="submit" class="btn">Save</button>
+                    </form>
+                  </td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      <?php else: ?>
+        <p>No shipments require attention right now.</p>
+      <?php endif; ?>
+    </section>
+
+    <section
+      id="manager-panel-sync"
+      class="store__panel<?= $activeTab === 'sync' ? ' is-active' : ''; ?>"
+      role="tabpanel"
+      aria-labelledby="manager-tab-sync"
+      <?= $activeTab === 'sync' ? '' : 'hidden'; ?>
+    >
+      <h2>Sync</h2>
+      <p>Square integration flags and runtime hints.</p>
+      <ul>
+        <li>Square sync: <?= !empty($syncState['enabled']) ? 'Enabled' : 'Disabled'; ?></li>
+        <li>Sync direction: <?= htmlspecialchars((string) $syncState['direction'], ENT_QUOTES, 'UTF-8'); ?></li>
+        <li>Orders API: <?= !empty($syncState['orders_flag']) ? 'Enabled' : 'Disabled'; ?></li>
+      </ul>
+      <p>Deeper telemetry will surface here once the sync daemon reports heartbeat metrics.</p>
+    </section>
+
+    <section
+      id="manager-panel-reports"
+      class="store__panel<?= $activeTab === 'reports' ? ' is-active' : ''; ?>"
+      role="tabpanel"
+      aria-labelledby="manager-tab-reports"
+      <?= $activeTab === 'reports' ? '' : 'hidden'; ?>
+    >
+      <h2>Reports</h2>
+      <p>Snapshot of marketplace activity to guide staffing and support follow-up.</p>
+      <div class="report-cards">
+        <div class="report-card">
+          <h3>Total products</h3>
+          <p><?= (int) $reports['total_products']; ?></p>
+        </div>
+        <div class="report-card">
+          <h3>Official catalog</h3>
+          <p><?= (int) $reports['official_products']; ?></p>
+        </div>
+        <div class="report-card">
+          <h3>Pending listing updates</h3>
+          <p><?= (int) $reports['pending_listing_requests']; ?></p>
+        </div>
+        <div class="report-card">
+          <h3>Open orders</h3>
+          <p><?= (int) $reports['open_orders']; ?></p>
+        </div>
+      </div>
+      <p>Expanded analytics will follow in later phases once the event stream is available.</p>
+    </section>
+  </div>
+  <?php include __DIR__ . '/../includes/footer.php'; ?>
+</body>
+</html>

--- a/admin/order-update.php
+++ b/admin/order-update.php
@@ -1,4 +1,8 @@
 <?php
+/*
+ * Discovery note: Admin update endpoint expected the legacy pending/shipped workflow.
+ * Change: Keeps flash messaging but now aligns with the staged lifecycle introduced in Shop Manager V1.
+ */
 require_once __DIR__ . '/../includes/require-auth.php';
 require_once __DIR__ . '/../includes/authz.php';
 require '../includes/db.php';

--- a/config.example.php
+++ b/config.example.php
@@ -1,4 +1,9 @@
 <?php
+/*
+ * Discovery note: Example configuration lagged behind the live feature toggles.
+ * Change: Documented the Square-related flags so new installs match the current rollout options
+ *         and highlighted the webhook signature key used to validate Square callbacks.
+ */
 // Copy this file to config.php and fill in real credentials.
 // Never commit your actual config.php to version control.
 return [
@@ -23,5 +28,13 @@ return [
   'square_location_id' => 'LXXXXXXXXXXXX',
   'square_access_token' => 'EAAAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
   'square_environment' => 'sandbox', // or 'production'
-  'SQUARE_CATALOG_SYNC' => false,
+  'square_webhook_signature_key' => '',
+
+  // Square feature flags
+  'USE_SQUARE_ORDERS' => false,
+  'SQUARE_SYNC_ENABLED' => false,
+  'SQUARE_SYNC_DIRECTION' => 'pull', // 'pull'|'push'|'two_way'
+
+  // Manager workspace rollout
+  'SHOP_MANAGER_V1_ENABLED' => false,
 ];

--- a/config.php
+++ b/config.php
@@ -1,4 +1,9 @@
 <?php
+/*
+ * Discovery note: Config already combines database, SMTP, and Square keys.
+ * Change: Added Square feature toggles earlier, introduced a manager UI flag for phased rollout,
+ *         and now expose the webhook signature key for securing inbound events.
+ */
 // Copy this file to config.php and fill in real credentials.
 // Never commit your actual config.php to version control.
 return [
@@ -25,4 +30,11 @@ return [
   'square_location_id' => 'LTXYAJY9GR996',
   'square_access_token' => 'EAAAly0J7zt7XMl2qEIGK_WmWB_i4v-KYU9tDWKPxPO0VcpwNNqIu89DDjMddFO_',
   'square_environment' => 'sandbox', // or 'production'
+  'square_webhook_signature_key' => '',
+
+  // Square feature flags
+  'USE_SQUARE_ORDERS' => false,
+  'SQUARE_SYNC_ENABLED' => false,
+  'SQUARE_SYNC_DIRECTION' => 'pull', // 'pull'|'push'|'two_way'
+  'SHOP_MANAGER_V1_ENABLED' => false,
 ];

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,4 +1,8 @@
 <?php
+/*
+ * Discovery note: Dashboard already surfaced admin panel access but offered no direct route to system diagnostics.
+ * Change: Added Square Health link for admins alongside documenting the new Square observability entry point.
+ */
 require_once __DIR__ . '/includes/require-auth.php';
 require 'includes/db.php';
 require 'includes/notifications.php';
@@ -76,6 +80,7 @@ $orders = fetch_orders_for_user($conn, (int) $id);
         <ul class="nav-links">
           <?php if (is_admin()): ?>
             <li><a class="btn" role="button" href="/admin/index.php">Admin Panel</a></li>
+            <li><a class="btn" role="button" href="/admin/health.php">Square Health</a></li>
           <?php elseif (is_skuze_official()): ?>
             <li><a class="btn" role="button" href="/admin/products.php">Official Inventory</a></li>
           <?php endif; ?>

--- a/includes/OrderService.php
+++ b/includes/OrderService.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Discovery note: The app lacked a way to create Square Orders when preparing payments.
+ * Change: Added a lightweight order service that wraps the new HTTP client to build orders when enabled.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/square-log.php';
+require_once __DIR__ . '/SquareHttpClient.php';
+
+final class OrderService
+{
+    private SquareHttpClient $client;
+
+    public function __construct(SquareHttpClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $lineItems
+     * @param array{taxes?: array<int, array<string, mixed>>, discounts?: array<int, array<string, mixed>>} $adjustments
+     */
+    public function createOrder(array $lineItems, array $adjustments = [], ?string $locationId = null): string
+    {
+        if (empty($lineItems)) {
+            throw new InvalidArgumentException('Square orders require at least one line item.');
+        }
+
+        $location = $locationId !== null && $locationId !== ''
+            ? $locationId
+            : $this->client->getLocationId();
+
+        $payload = [
+            'idempotency_key' => bin2hex(random_bytes(16)),
+            'order' => [
+                'location_id' => $location,
+                'line_items' => array_values($lineItems),
+            ],
+        ];
+
+        if (!empty($adjustments['taxes'])) {
+            $payload['order']['taxes'] = array_values($adjustments['taxes']);
+        }
+        if (!empty($adjustments['discounts'])) {
+            $payload['order']['discounts'] = array_values($adjustments['discounts']);
+        }
+
+        $response = $this->client->request('POST', '/v2/orders', $payload, $payload['idempotency_key']);
+
+        if ($response['statusCode'] < 200 || $response['statusCode'] >= 300) {
+            square_log('square.order_http_error', [
+                'status' => $response['statusCode'],
+                'body' => $response['raw'],
+            ]);
+            throw new RuntimeException('Square order creation failed.');
+        }
+
+        $body = $response['body'];
+        if (!is_array($body) || !isset($body['order']['id'])) {
+            square_log('square.order_missing_id', [
+                'status' => $response['statusCode'],
+                'body' => $response['raw'],
+            ]);
+            throw new RuntimeException('Square order response missing identifier.');
+        }
+
+        $orderId = (string)$body['order']['id'];
+        square_log('square.order_created', [
+            'order_id' => $orderId,
+            'location_id' => $location,
+        ]);
+
+        return $orderId;
+    }
+}

--- a/includes/SquareHttpClient.php
+++ b/includes/SquareHttpClient.php
@@ -1,0 +1,213 @@
+<?php
+/*
+ * Discovery note: Existing payment flow hand-crafted cURL calls without shared error handling or config validation.
+ * Change: Added a reusable Square HTTP client that validates configuration and centralizes retries/logging.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/square-log.php';
+
+final class SquareConfigException extends RuntimeException
+{
+}
+
+final class SquareHttpClient
+{
+    private const SQUARE_VERSION = '2024-08-15';
+
+    private string $environment;
+    private string $baseUrl;
+    private string $accessToken;
+    private string $locationId;
+    private string $applicationId;
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(array $config)
+    {
+        $this->environment = strtolower(trim((string)($config['square_environment'] ?? 'sandbox')));
+        if ($this->environment === '') {
+            $this->environment = 'sandbox';
+        }
+
+        if (!in_array($this->environment, ['sandbox', 'production'], true)) {
+            square_log('square.config_invalid_environment', ['environment' => $this->environment]);
+            http_response_code(500);
+            throw new SquareConfigException('Unsupported Square environment configuration.');
+        }
+
+        $this->accessToken = $this->requireConfig($config, 'square_access_token');
+        $this->locationId = $this->requireConfig($config, 'square_location_id');
+        $this->applicationId = $this->requireConfig($config, 'square_application_id');
+
+        $this->baseUrl = $this->environment === 'production'
+            ? 'https://connect.squareup.com'
+            : 'https://connect.squareupsandbox.com';
+    }
+
+    public function getEnvironment(): string
+    {
+        return $this->environment;
+    }
+
+    public function getLocationId(): string
+    {
+        return $this->locationId;
+    }
+
+    public function getApplicationId(): string
+    {
+        return $this->applicationId;
+    }
+
+    public function getBaseUrl(): string
+    {
+        return $this->baseUrl;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array{statusCode: int, body: mixed, raw: string}
+     */
+    public function request(
+        string $method,
+        string $path,
+        ?array $payload = null,
+        ?string $idempotencyKey = null
+    ): array {
+        $method = strtoupper($method);
+        $attempts = 0;
+        $maxAttempts = 3;
+        $backoffSeconds = 1.0;
+        $raw = '';
+        $decoded = null;
+        $statusCode = 0;
+        $errorMessage = null;
+
+        $urlPath = strpos($path, 'http') === 0 ? $path : $this->baseUrl . $path;
+
+        while ($attempts < $maxAttempts) {
+            $attempts++;
+
+            $headers = [
+                'Content-Type: application/json',
+                'Accept: application/json',
+                'Square-Version: ' . self::SQUARE_VERSION,
+                'Authorization: Bearer ' . $this->accessToken,
+            ];
+            if ($idempotencyKey !== null && $idempotencyKey !== '') {
+                $headers[] = 'Idempotency-Key: ' . $idempotencyKey;
+            }
+
+            $options = [
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_TIMEOUT => 30,
+                CURLOPT_HTTPHEADER => $headers,
+                CURLOPT_FAILONERROR => false,
+            ];
+
+            $targetUrl = $urlPath;
+
+            if ($method === 'GET' && !empty($payload)) {
+                $query = http_build_query($payload);
+                $targetUrl .= (str_contains($targetUrl, '?') ? '&' : '?') . $query;
+            } elseif ($payload !== null) {
+                $json = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                if ($json === false) {
+                    throw new RuntimeException('Failed to encode Square request payload.');
+                }
+                $options[CURLOPT_POSTFIELDS] = $json;
+            }
+
+            if ($method === 'POST') {
+                $options[CURLOPT_POST] = true;
+            } else {
+                $options[CURLOPT_CUSTOMREQUEST] = $method;
+            }
+
+            $options[CURLOPT_URL] = $targetUrl;
+
+            $handle = curl_init();
+            if ($handle === false) {
+                throw new RuntimeException('Unable to initialize Square cURL handle.');
+            }
+
+            curl_setopt_array($handle, $options);
+
+            $raw = (string)curl_exec($handle);
+            $curlErrNo = curl_errno($handle);
+            $curlErr = $curlErrNo !== 0 ? curl_error($handle) : null;
+            $statusCode = (int)curl_getinfo($handle, CURLINFO_HTTP_CODE);
+            curl_close($handle);
+
+            if ($curlErrNo !== 0) {
+                $errorMessage = 'Transport error: ' . $curlErr;
+                square_log('square.http_transport_error', [
+                    'path' => $path,
+                    'attempt' => $attempts,
+                    'error' => $curlErr,
+                ]);
+            } else {
+                $decoded = json_decode($raw, true);
+                if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+                    $errorMessage = 'Invalid JSON response.';
+                    square_log('square.http_invalid_json', [
+                        'path' => $path,
+                        'status' => $statusCode,
+                        'body' => $raw,
+                    ]);
+                } elseif ($statusCode === 429 || ($statusCode >= 500 && $statusCode < 600)) {
+                    $errorMessage = 'Square responded with retryable status.';
+                    square_log('square.http_retry', [
+                        'path' => $path,
+                        'status' => $statusCode,
+                        'attempt' => $attempts,
+                    ]);
+                } else {
+                    $errorMessage = null;
+                }
+            }
+
+            if ($errorMessage === null) {
+                break;
+            }
+
+            if ($attempts < $maxAttempts) {
+                usleep((int)($backoffSeconds * 1_000_000));
+                $backoffSeconds *= 2;
+            }
+        }
+
+        if ($errorMessage !== null) {
+            square_log('square.http_failure', [
+                'path' => $path,
+                'status' => $statusCode,
+                'error' => $errorMessage,
+                'body' => $raw,
+            ]);
+            throw new RuntimeException('Square request failed: ' . $errorMessage);
+        }
+
+        return [
+            'statusCode' => $statusCode,
+            'body' => $decoded,
+            'raw' => $raw,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function requireConfig(array $config, string $key): string
+    {
+        $value = trim((string)($config[$key] ?? ''));
+        if ($value === '') {
+            square_log('square.config_missing', ['key' => $key]);
+            http_response_code(500);
+            throw new SquareConfigException('Missing Square configuration: ' . $key);
+        }
+        return $value;
+    }
+}

--- a/includes/SyncService.php
+++ b/includes/SyncService.php
@@ -1,0 +1,846 @@
+<?php
+/*
+ * Discovery note: Square sync logic previously lived in ad-hoc helpers without catalog or
+ * inventory reconciliation routines.
+ * Change: Introduced a feature-gated SyncService that can pull catalog data, refresh inventory
+ *         counts, and stage push operations while recording sync health state.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/square-log.php';
+require_once __DIR__ . '/SquareHttpClient.php';
+require_once __DIR__ . '/square-migrations.php';
+require_once __DIR__ . '/repositories/InventoryService.php';
+
+final class SyncService
+{
+    private mysqli $conn;
+    private array $config;
+    private ?SquareHttpClient $client = null;
+    private InventoryService $inventory;
+    private bool $enabled;
+    private string $direction;
+    private string $stateKey = 'square_core';
+    private bool $catalogMapAvailable;
+    private bool $modifierTableAvailable;
+
+    public function __construct(mysqli $conn, array $config)
+    {
+        $this->conn = $conn;
+        $this->config = $config;
+        $this->enabled = !empty($config['SQUARE_SYNC_ENABLED']);
+        $direction = strtolower((string) ($config['SQUARE_SYNC_DIRECTION'] ?? 'pull'));
+        $this->direction = in_array($direction, ['pull', 'push', 'two_way'], true) ? $direction : 'pull';
+        $this->inventory = new InventoryService($conn);
+
+        square_run_migrations($conn);
+        $this->catalogMapAvailable = $this->tableExists('square_catalog_map');
+        $this->modifierTableAvailable = $this->tableExists('product_modifiers');
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Pull Square catalog objects and update local metadata.
+     *
+     * @return array{status: string, variation_ids?: array<int, string>, synced_listings?: int, modifier_updates?: int}
+     */
+    public function pullCatalog(): array
+    {
+        if (!$this->enabled) {
+            return ['status' => 'disabled'];
+        }
+
+        $client = $this->getClient();
+
+        $cursor = null;
+        $items = [];
+        $variations = [];
+        $modifierLists = [];
+        $apiCalls = 0;
+
+        do {
+            $params = ['types' => 'ITEM,ITEM_VARIATION,MODIFIER_LIST'];
+            if ($cursor !== null) {
+                $params['cursor'] = $cursor;
+            }
+
+            try {
+                $response = $client->request('GET', '/v2/catalog/list', $params);
+            } catch (Throwable $e) {
+                $this->recordSyncError('catalog_request_failed', $e->getMessage(), ['cursor' => $cursor]);
+                throw $e;
+            }
+
+            $apiCalls++;
+            if ($response['statusCode'] < 200 || $response['statusCode'] >= 300) {
+                $this->recordSyncError('catalog_http_error', 'Square catalog list failed.', [
+                    'status' => $response['statusCode'],
+                    'body' => $response['raw'],
+                ]);
+                throw new RuntimeException('Square catalog request failed.');
+            }
+
+            $body = $response['body'];
+            if (!is_array($body)) {
+                $this->recordSyncError('catalog_invalid_body', 'Square catalog response missing payload.');
+                throw new RuntimeException('Square catalog response invalid.');
+            }
+
+            $objects = $body['objects'] ?? [];
+            if (is_array($objects)) {
+                foreach ($objects as $object) {
+                    if (!is_array($object)) {
+                        continue;
+                    }
+                    $type = (string) ($object['type'] ?? '');
+                    $id = (string) ($object['id'] ?? '');
+                    if ($id === '') {
+                        continue;
+                    }
+                    switch ($type) {
+                        case 'ITEM':
+                            $items[$id] = $object;
+                            break;
+                        case 'ITEM_VARIATION':
+                            $variations[$id] = $object;
+                            break;
+                        case 'MODIFIER_LIST':
+                            $modifierLists[$id] = $object;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+
+            $cursor = isset($body['cursor']) && is_string($body['cursor']) && $body['cursor'] !== ''
+                ? $body['cursor']
+                : null;
+        } while ($cursor !== null);
+
+        $variationSkuMap = [];
+        foreach ($variations as $variationId => $variation) {
+            if (!is_array($variation)) {
+                continue;
+            }
+            $data = $variation['item_variation_data'] ?? [];
+            if (!is_array($data)) {
+                continue;
+            }
+            $sku = trim((string) ($data['sku'] ?? ''));
+            if ($sku === '') {
+                continue;
+            }
+            $variationSkuMap[$variationId] = [
+                'sku' => $sku,
+                'item_id' => (string) ($data['item_id'] ?? ''),
+                'object' => $variation,
+            ];
+        }
+
+        $skuToListingIds = [];
+        $skus = array_values(array_unique(array_map(static fn(array $meta): string => $meta['sku'], $variationSkuMap)));
+        if ($skus) {
+            $placeholders = implode(',', array_fill(0, count($skus), '?'));
+            $types = str_repeat('s', count($skus));
+            $sql = 'SELECT id, product_sku FROM listings WHERE product_sku IN (' . $placeholders . ')';
+            if ($stmt = $this->conn->prepare($sql)) {
+                $stmt->bind_param($types, ...$skus);
+                if ($stmt->execute() && ($result = $stmt->get_result())) {
+                    while ($row = $result->fetch_assoc()) {
+                        $sku = (string) ($row['product_sku'] ?? '');
+                        if ($sku === '') {
+                            continue;
+                        }
+                        $skuToListingIds[$sku][] = (int) $row['id'];
+                    }
+                    $result->free();
+                }
+                $stmt->close();
+            }
+        }
+
+        $syncedListings = 0;
+        if ($this->catalogMapAvailable) {
+            foreach ($variationSkuMap as $variationId => $meta) {
+                $sku = $meta['sku'];
+                $listingIds = $skuToListingIds[$sku] ?? [];
+                foreach ($listingIds as $listingId) {
+                    if ($this->upsertCatalogMap('listing', $listingId, $variationId)) {
+                        $syncedListings++;
+                    }
+                }
+            }
+        }
+
+        $modifierUpdates = 0;
+        if ($this->modifierTableAvailable) {
+            $skuModifierMap = [];
+            foreach ($items as $itemId => $item) {
+                if (!is_array($item)) {
+                    continue;
+                }
+                $itemData = $item['item_data'] ?? [];
+                if (!is_array($itemData)) {
+                    continue;
+                }
+                $modifierRefs = $itemData['modifier_list_info'] ?? [];
+                $modifierIds = [];
+                if (is_array($modifierRefs)) {
+                    foreach ($modifierRefs as $ref) {
+                        if (is_array($ref) && isset($ref['modifier_list_id'])) {
+                            $modifierId = (string) $ref['modifier_list_id'];
+                            if ($modifierId !== '') {
+                                $modifierIds[] = $modifierId;
+                            }
+                        }
+                    }
+                }
+
+                $variationRefs = $itemData['variations'] ?? [];
+                if (is_array($variationRefs)) {
+                    foreach ($variationRefs as $ref) {
+                        if (!is_array($ref)) {
+                            continue;
+                        }
+                        $variationId = isset($ref['id']) ? (string) $ref['id'] : '';
+                        if ($variationId === '') {
+                            continue;
+                        }
+                        if (!isset($variationSkuMap[$variationId])) {
+                            continue;
+                        }
+                        $sku = $variationSkuMap[$variationId]['sku'];
+                        $skuModifierMap[$sku] = [
+                            'item_id' => $itemId,
+                            'variation_id' => $variationId,
+                            'modifier_list_ids' => $modifierIds,
+                        ];
+                    }
+                }
+            }
+
+            foreach ($skuModifierMap as $sku => $meta) {
+                $modifierPayload = [];
+                foreach ($meta['modifier_list_ids'] as $modifierId) {
+                    if (isset($modifierLists[$modifierId]) && is_array($modifierLists[$modifierId])) {
+                        $modifierPayload[] = $modifierLists[$modifierId];
+                    }
+                }
+
+                $data = [
+                    'square_item_id' => $meta['item_id'],
+                    'square_variation_id' => $meta['variation_id'],
+                    'modifier_list_ids' => $meta['modifier_list_ids'],
+                    'modifier_lists' => $modifierPayload,
+                ];
+                $primaryModifier = $meta['modifier_list_ids'][0] ?? null;
+                if ($this->upsertProductModifier($sku, $data, $primaryModifier)) {
+                    $modifierUpdates++;
+                }
+            }
+        }
+
+        $now = date('Y-m-d H:i:s');
+        $this->touchSyncState([
+            'last_synced_at' => $now,
+            'sync_direction' => $this->direction,
+        ]);
+
+        square_log('square.sync_pull_catalog_complete', [
+            'variations' => count($variationSkuMap),
+            'listings_mapped' => $syncedListings,
+            'modifier_updates' => $modifierUpdates,
+            'api_calls' => $apiCalls,
+        ]);
+
+        return [
+            'status' => 'ok',
+            'variation_ids' => array_keys($variationSkuMap),
+            'synced_listings' => $syncedListings,
+            'modifier_updates' => $modifierUpdates,
+        ];
+    }
+
+    /**
+     * Pull Square inventory counts for the provided variation IDs.
+     *
+     * @param array<int, string> $variationIds
+     * @return array{status: string, applied?: int}
+     */
+    public function pullInventory(array $variationIds): array
+    {
+        if (!$this->enabled) {
+            return ['status' => 'disabled'];
+        }
+
+        if (!$variationIds) {
+            return ['status' => 'no_variations'];
+        }
+
+        $client = $this->getClient();
+        $applied = 0;
+
+        foreach (array_chunk($variationIds, 50) as $chunk) {
+            $payload = [
+                'catalog_object_ids' => array_values(array_filter($chunk, static fn($id): bool => is_string($id) && $id !== '')),
+            ];
+            if (!$payload['catalog_object_ids']) {
+                continue;
+            }
+
+            try {
+                $response = $client->request(
+                    'POST',
+                    '/v2/inventory/batch-retrieve-counts',
+                    $payload,
+                    bin2hex(random_bytes(16))
+                );
+            } catch (Throwable $e) {
+                $this->recordSyncError('inventory_request_failed', $e->getMessage(), ['chunk' => $chunk]);
+                continue;
+            }
+
+            if ($response['statusCode'] < 200 || $response['statusCode'] >= 300) {
+                $this->recordSyncError('inventory_http_error', 'Inventory retrieve failed.', [
+                    'status' => $response['statusCode'],
+                    'body' => $response['raw'],
+                ]);
+                continue;
+            }
+
+            $body = $response['body'];
+            if (!is_array($body) || !isset($body['counts']) || !is_array($body['counts'])) {
+                continue;
+            }
+
+            foreach ($body['counts'] as $count) {
+                if (!is_array($count)) {
+                    continue;
+                }
+                $squareId = isset($count['catalog_object_id']) ? (string) $count['catalog_object_id'] : '';
+                if ($squareId === '') {
+                    continue;
+                }
+
+                $quantity = $count['quantity'] ?? null;
+                if ($quantity === null) {
+                    continue;
+                }
+                $quantityValue = is_string($quantity) || is_numeric($quantity)
+                    ? (int) floor((float) $quantity)
+                    : null;
+                if ($quantityValue === null) {
+                    continue;
+                }
+                if ($quantityValue < 0) {
+                    $quantityValue = 0;
+                }
+
+                $sku = $this->lookupSkuForSquareId($squareId);
+                if ($sku === null) {
+                    continue;
+                }
+
+                try {
+                    $result = $this->inventory->reconcileExternalStock(
+                        $sku,
+                        $quantityValue,
+                        'square_webhook',
+                        null,
+                        [
+                            'square_object_id' => $squareId,
+                            'source' => 'pull_inventory',
+                            'state' => $count['state'] ?? null,
+                        ]
+                    );
+                    if ($result !== null) {
+                        $applied++;
+                    }
+                } catch (Throwable $e) {
+                    $this->recordSyncError('inventory_update_failed', $e->getMessage(), [
+                        'square_object_id' => $squareId,
+                        'sku' => $sku,
+                    ]);
+                }
+            }
+        }
+
+        $this->touchSyncState(['last_synced_at' => date('Y-m-d H:i:s')]);
+
+        square_log('square.sync_pull_inventory_complete', [
+            'applied' => $applied,
+        ]);
+
+        return ['status' => 'ok', 'applied' => $applied];
+    }
+
+    /**
+     * Push local catalog updates to Square for the provided listing IDs.
+     *
+     * @param array<int, int> $localIds
+     * @return array{status: string, synced?: int}
+     */
+    public function pushCatalog(array $localIds): array
+    {
+        if (!$this->enabled) {
+            return ['status' => 'disabled'];
+        }
+
+        if ($this->direction === 'pull') {
+            square_log('square.sync_push_skipped', ['reason' => 'direction_pull_only']);
+            return ['status' => 'skipped'];
+        }
+
+        if (!$localIds) {
+            return ['status' => 'no_ids'];
+        }
+
+        $client = $this->getClient();
+        $synced = 0;
+
+        foreach ($localIds as $listingId) {
+            $listingId = (int) $listingId;
+            if ($listingId <= 0) {
+                continue;
+            }
+
+            $listing = $this->fetchListing($listingId);
+            if ($listing === null) {
+                continue;
+            }
+
+            $sku = $listing['product_sku'] !== '' ? $listing['product_sku'] : 'listing-' . $listingId;
+            $priceCents = (int) round((float) $listing['price'] * 100);
+            if ($priceCents < 0) {
+                $priceCents = 0;
+            }
+
+            $existingMapId = $this->lookupCatalogMap($listingId);
+            $modifierMeta = $this->fetchModifierMeta($sku);
+            $existingItemId = $modifierMeta['square_item_id'] ?? null;
+            $existingVariationId = $modifierMeta['square_variation_id'] ?? $existingMapId;
+
+            $payload = $this->buildCatalogUpsertPayload(
+                $listing,
+                $sku,
+                $priceCents,
+                $existingItemId,
+                $existingVariationId
+            );
+
+            try {
+                $response = $client->request('POST', '/v2/catalog/object', $payload, $payload['idempotency_key']);
+            } catch (Throwable $e) {
+                $this->recordSyncError('catalog_push_failed', $e->getMessage(), [
+                    'listing_id' => $listingId,
+                ]);
+                continue;
+            }
+
+            if ($response['statusCode'] < 200 || $response['statusCode'] >= 300) {
+                $this->recordSyncError('catalog_push_http_error', 'Catalog push failed.', [
+                    'listing_id' => $listingId,
+                    'status' => $response['statusCode'],
+                    'body' => $response['raw'],
+                ]);
+                continue;
+            }
+
+            $body = $response['body'];
+            if (!is_array($body)) {
+                continue;
+            }
+
+            $resolved = $this->resolveCatalogIdentifiers($body, $existingItemId, $existingVariationId);
+            if ($resolved['variation_id'] === null) {
+                continue;
+            }
+
+            $this->upsertCatalogMap('listing', $listingId, $resolved['variation_id']);
+            $this->upsertProductModifier($sku, [
+                'square_item_id' => $resolved['item_id'],
+                'square_variation_id' => $resolved['variation_id'],
+            ], null);
+
+            $synced++;
+        }
+
+        if ($synced > 0) {
+            $this->touchSyncState(['last_synced_at' => date('Y-m-d H:i:s')]);
+        }
+
+        square_log('square.sync_push_complete', [
+            'synced' => $synced,
+        ]);
+
+        return ['status' => 'ok', 'synced' => $synced];
+    }
+
+    private function getClient(): SquareHttpClient
+    {
+        if ($this->client === null) {
+            $this->client = new SquareHttpClient($this->config);
+        }
+
+        return $this->client;
+    }
+
+    private function tableExists(string $table): bool
+    {
+        $stmt = $this->conn->prepare("SHOW TABLES LIKE ?");
+        if ($stmt === false) {
+            return false;
+        }
+
+        $stmt->bind_param('s', $table);
+        $exists = false;
+        if ($stmt->execute() && ($result = $stmt->get_result())) {
+            $exists = $result->num_rows > 0;
+            $result->free();
+        }
+        $stmt->close();
+
+        return $exists;
+    }
+
+    private function upsertCatalogMap(string $type, int $localId, string $squareId): bool
+    {
+        if (!$this->catalogMapAvailable || $squareId === '') {
+            return false;
+        }
+
+        $stmt = $this->conn->prepare(
+            'INSERT INTO square_catalog_map (local_type, local_id, square_object_id, sync_status, last_synced_at, updated_at) '
+            . 'VALUES (?, ?, ?, "synced", NOW(), NOW()) '
+            . 'ON DUPLICATE KEY UPDATE square_object_id = VALUES(square_object_id), '
+            . 'sync_status = "synced", updated_at = NOW(), last_synced_at = NOW()'
+        );
+
+        if ($stmt === false) {
+            return false;
+        }
+
+        $stmt->bind_param('sis', $type, $localId, $squareId);
+        $executed = $stmt->execute();
+        $stmt->close();
+
+        return $executed;
+    }
+
+    private function upsertProductModifier(string $sku, array $data, ?string $primaryModifierId): bool
+    {
+        if (!$this->modifierTableAvailable || $sku === '') {
+            return false;
+        }
+
+        $json = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            $json = null;
+        }
+
+        $stmt = $this->conn->prepare(
+            'INSERT INTO product_modifiers (product_sku, square_modifier_list_id, data, created_at, updated_at) '
+            . 'VALUES (?, ?, ?, NOW(), NOW()) '
+            . 'ON DUPLICATE KEY UPDATE square_modifier_list_id = VALUES(square_modifier_list_id), '
+            . 'data = VALUES(data), updated_at = NOW()'
+        );
+
+        if ($stmt === false) {
+            return false;
+        }
+
+        $stmt->bind_param('sss', $sku, $primaryModifierId, $json);
+        $result = $stmt->execute();
+        $stmt->close();
+
+        return $result;
+    }
+
+    private function touchSyncState(array $fields): void
+    {
+        if (!$fields) {
+            return;
+        }
+
+        $columns = [];
+        $updates = [];
+        $types = 's';
+        $values = [$this->stateKey];
+
+        foreach ($fields as $column => $value) {
+            $columns[] = sprintf('`%s`', $column);
+            $updates[] = sprintf('`%s` = VALUES(`%s`)', $column, $column);
+            $types .= 's';
+            $values[] = (string) $value;
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($columns) + 1, '?'));
+        $sql = sprintf(
+            'INSERT INTO square_sync_state (setting_key, %s) VALUES (%s) ON DUPLICATE KEY UPDATE %s',
+            implode(', ', $columns),
+            $placeholders,
+            implode(', ', $updates)
+        );
+
+        $stmt = $this->conn->prepare($sql);
+        if ($stmt === false) {
+            return;
+        }
+
+        $stmt->bind_param($types, ...$values);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    private function recordSyncError(string $code, string $message, array $context = []): void
+    {
+        $json = $context ? json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : null;
+        $stmt = $this->conn->prepare(
+            'INSERT INTO square_sync_errors (error_code, message, context, created_at) VALUES (?, ?, ?, NOW())'
+        );
+        if ($stmt === false) {
+            return;
+        }
+        $stmt->bind_param('sss', $code, $message, $json);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    private function lookupSkuForSquareId(string $squareId): ?string
+    {
+        if (!$this->catalogMapAvailable) {
+            return null;
+        }
+
+        $stmt = $this->conn->prepare(
+            'SELECT l.product_sku FROM square_catalog_map scm '
+            . 'JOIN listings l ON l.id = scm.local_id '
+            . 'WHERE scm.local_type = "listing" AND scm.square_object_id = ? LIMIT 1'
+        );
+        if ($stmt === false) {
+            return null;
+        }
+
+        $stmt->bind_param('s', $squareId);
+        $sku = null;
+        if ($stmt->execute() && ($result = $stmt->get_result())) {
+            if ($row = $result->fetch_assoc()) {
+                $candidate = (string) ($row['product_sku'] ?? '');
+                if ($candidate !== '') {
+                    $sku = $candidate;
+                }
+            }
+            $result->free();
+        }
+        $stmt->close();
+
+        return $sku;
+    }
+
+    private function fetchListing(int $listingId): ?array
+    {
+        $stmt = $this->conn->prepare(
+            'SELECT l.id, l.title, l.price, l.quantity, COALESCE(l.product_sku, "") AS product_sku '
+            . 'FROM listings l WHERE l.id = ? LIMIT 1'
+        );
+        if ($stmt === false) {
+            return null;
+        }
+
+        $stmt->bind_param('i', $listingId);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            return null;
+        }
+
+        $result = $stmt->get_result();
+        $row = $result ? $result->fetch_assoc() : null;
+        if ($result) {
+            $result->free();
+        }
+        $stmt->close();
+
+        if (!$row) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $row['id'],
+            'title' => (string) ($row['title'] ?? ''),
+            'price' => (float) $row['price'],
+            'quantity' => (int) ($row['quantity'] ?? 0),
+            'product_sku' => (string) $row['product_sku'],
+        ];
+    }
+
+    private function lookupCatalogMap(int $listingId): ?string
+    {
+        if (!$this->catalogMapAvailable) {
+            return null;
+        }
+
+        $stmt = $this->conn->prepare(
+            'SELECT square_object_id FROM square_catalog_map WHERE local_type = "listing" AND local_id = ? LIMIT 1'
+        );
+        if ($stmt === false) {
+            return null;
+        }
+        $stmt->bind_param('i', $listingId);
+        $squareId = null;
+        if ($stmt->execute()) {
+            $stmt->bind_result($squareObjectId);
+            if ($stmt->fetch()) {
+                $squareId = (string) $squareObjectId;
+            }
+        }
+        $stmt->close();
+        return $squareId ?: null;
+    }
+
+    private function fetchModifierMeta(string $sku): array
+    {
+        if (!$this->modifierTableAvailable || $sku === '') {
+            return [];
+        }
+
+        $stmt = $this->conn->prepare('SELECT data FROM product_modifiers WHERE product_sku = ? LIMIT 1');
+        if ($stmt === false) {
+            return [];
+        }
+
+        $stmt->bind_param('s', $sku);
+        $meta = [];
+        if ($stmt->execute()) {
+            $stmt->bind_result($data);
+            if ($stmt->fetch() && is_string($data) && $data !== '') {
+                $decoded = json_decode($data, true);
+                if (is_array($decoded)) {
+                    $meta = $decoded;
+                }
+            }
+        }
+        $stmt->close();
+
+        return $meta;
+    }
+
+    /**
+     * @return array{item_id: ?string, variation_id: ?string}
+     */
+    private function resolveCatalogIdentifiers(array $body, ?string $itemId, ?string $variationId): array
+    {
+        $resolvedItemId = $itemId;
+        $resolvedVariationId = $variationId;
+
+        if (isset($body['catalog_object']) && is_array($body['catalog_object'])) {
+            $object = $body['catalog_object'];
+            $type = (string) ($object['type'] ?? '');
+            if ($type === 'ITEM') {
+                $resolvedItemId = (string) ($object['id'] ?? $resolvedItemId);
+                $itemData = $object['item_data'] ?? [];
+                if (is_array($itemData) && isset($itemData['variations']) && is_array($itemData['variations'])) {
+                    foreach ($itemData['variations'] as $variation) {
+                        if (is_array($variation) && isset($variation['id'])) {
+                            $resolvedVariationId = (string) $variation['id'];
+                        }
+                    }
+                }
+            } elseif ($type === 'ITEM_VARIATION') {
+                $resolvedVariationId = (string) ($object['id'] ?? $resolvedVariationId);
+                $data = $object['item_variation_data'] ?? [];
+                if (is_array($data) && isset($data['item_id'])) {
+                    $resolvedItemId = (string) $data['item_id'];
+                }
+            }
+        }
+
+        if (isset($body['related_objects']) && is_array($body['related_objects'])) {
+            foreach ($body['related_objects'] as $related) {
+                if (!is_array($related)) {
+                    continue;
+                }
+                $type = (string) ($related['type'] ?? '');
+                if ($type === 'ITEM_VARIATION') {
+                    $resolvedVariationId = (string) ($related['id'] ?? $resolvedVariationId);
+                    $data = $related['item_variation_data'] ?? [];
+                    if (is_array($data) && isset($data['item_id'])) {
+                        $resolvedItemId = (string) $data['item_id'];
+                    }
+                } elseif ($type === 'ITEM' && $resolvedItemId === null) {
+                    $resolvedItemId = (string) ($related['id'] ?? $resolvedItemId);
+                }
+            }
+        }
+
+        return [
+            'item_id' => $resolvedItemId,
+            'variation_id' => $resolvedVariationId,
+        ];
+    }
+
+    private function buildCatalogUpsertPayload(
+        array $listing,
+        string $sku,
+        int $priceCents,
+        ?string $itemId,
+        ?string $variationId
+    ): array {
+        $idempotencyKey = bin2hex(random_bytes(16));
+        $title = trim($listing['title']);
+        if ($title === '') {
+            $title = 'Listing #' . $listing['id'];
+        }
+
+        if ($itemId !== null && $variationId !== null) {
+            return [
+                'idempotency_key' => $idempotencyKey,
+                'object' => [
+                    'type' => 'ITEM_VARIATION',
+                    'id' => $variationId,
+                    'item_variation_data' => [
+                        'item_id' => $itemId,
+                        'name' => 'Default',
+                        'sku' => $sku,
+                        'price_money' => [
+                            'amount' => $priceCents,
+                            'currency' => 'USD',
+                        ],
+                    ],
+                ],
+            ];
+        }
+
+        $itemAlias = $itemId ?? ('#ITEM-' . $listing['id']);
+        $variationAlias = $variationId ?? ('#VAR-' . $listing['id']);
+
+        return [
+            'idempotency_key' => $idempotencyKey,
+            'object' => [
+                'type' => 'ITEM',
+                'id' => $itemAlias,
+                'item_data' => [
+                    'name' => $title,
+                    'variations' => [[
+                        'type' => 'ITEM_VARIATION',
+                        'id' => $variationAlias,
+                        'item_variation_data' => [
+                            'item_id' => $itemAlias,
+                            'name' => 'Default',
+                            'sku' => $sku,
+                            'price_money' => [
+                                'amount' => $priceCents,
+                                'currency' => 'USD',
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ];
+    }
+}

--- a/includes/orders.php
+++ b/includes/orders.php
@@ -1,4 +1,8 @@
 <?php
+/*
+ * Discovery note: Order helpers still referenced the legacy pending/processing flow.
+ * Change: Introduced the New→Completed lifecycle map while preserving compatibility aliases.
+ */
 /**
  * Helper functions for retrieving enriched order data.
  */
@@ -244,11 +248,15 @@ function _orders_normalize_row(array $row): array {
  */
 function order_fulfillment_status_options(): array {
     return [
-        'pending' => 'Pending',
-        'processing' => 'Processing',
+        'new' => 'New',
+        'paid' => 'Paid',
+        'packing' => 'Packing',
         'shipped' => 'Shipped',
         'delivered' => 'Delivered',
+        'completed' => 'Completed',
         'cancelled' => 'Cancelled',
+        'pending' => 'Pending', // legacy alias
+        'processing' => 'Packing', // legacy alias
     ];
 }
 

--- a/includes/repositories/ChangeRequestsService.php
+++ b/includes/repositories/ChangeRequestsService.php
@@ -1,4 +1,8 @@
 <?php
+/*
+ * Discovery note: Change request service only handled status moderation.
+ * Change: Added helpers for critical listing updates, targeted resolutions, and request lookups.
+ */
 declare(strict_types=1);
 
 require_once __DIR__ . '/ShopLogger.php';
@@ -62,6 +66,61 @@ final class ChangeRequestsService
     }
 
     /**
+     * Persist a critical field update request for moderation.
+     *
+     * @param array<string, mixed> $changes
+     */
+    public function createCriticalUpdateRequest(int $listingId, int $requesterId, array $changes, ?string $summary = null): ?int
+    {
+        if ($listingId <= 0 || $requesterId <= 0 || $changes === []) {
+            return null;
+        }
+
+        $payload = json_encode($changes, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($payload === false) {
+            $payload = null;
+        }
+
+        $stmt = $this->conn->prepare(
+            'INSERT INTO listing_change_requests '
+            . '(listing_id, requester_id, change_type, change_summary, payload) '
+            . 'VALUES (?, ?, "critical_update", ?, ?)'
+        );
+
+        if ($stmt === false) {
+            shop_log('change_request.error', [
+                'listing_id' => $listingId,
+                'requester_id' => $requesterId,
+                'error' => $this->conn->error,
+            ]);
+            return null;
+        }
+
+        $stmt->bind_param('iiss', $listingId, $requesterId, $summary, $payload);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            shop_log('change_request.error', [
+                'listing_id' => $listingId,
+                'requester_id' => $requesterId,
+                'error' => $stmt->error,
+            ]);
+            return null;
+        }
+
+        $id = (int) $stmt->insert_id;
+        $stmt->close();
+
+        shop_log('change_request.created', [
+            'id' => $id,
+            'listing_id' => $listingId,
+            'requester_id' => $requesterId,
+            'type' => 'critical_update',
+        ]);
+
+        return $id;
+    }
+
+    /**
      * Mark pending requests for the listing as approved by the reviewer.
      */
     public function approveOpenRequests(int $listingId, int $reviewerId, string $status): int
@@ -109,6 +168,81 @@ final class ChangeRequestsService
         }
 
         return $affected;
+    }
+
+    /**
+     * Resolve a single request without touching other pending entries.
+     */
+    public function markSingleRequest(
+        int $requestId,
+        string $status,
+        int $reviewerId,
+        ?string $requestedStatus = null,
+        string $note = ''
+    ): bool {
+        if ($requestId <= 0 || $reviewerId <= 0) {
+            return false;
+        }
+
+        $status = strtolower($status);
+        if (!in_array($status, ['approved', 'rejected', 'cancelled'], true)) {
+            return false;
+        }
+
+        $stmt = $this->conn->prepare(
+            'UPDATE listing_change_requests '
+            . 'SET status = ?, reviewer_id = ?, resolved_at = NOW(), review_notes = ?, '
+            . 'requested_status = COALESCE(requested_status, ?), updated_at = NOW() '
+            . 'WHERE id = ?'
+        );
+
+        if ($stmt === false) {
+            return false;
+        }
+
+        $stmt->bind_param('sissi', $status, $reviewerId, $note, $requestedStatus, $requestId);
+        $stmt->execute();
+        $affected = $stmt->affected_rows > 0;
+        $stmt->close();
+
+        if ($affected) {
+            shop_log('change_request.' . $status, [
+                'id' => $requestId,
+                'reviewer_id' => $reviewerId,
+                'status' => $requestedStatus,
+            ]);
+        }
+
+        return $affected;
+    }
+
+    /**
+     * Fetch a single change request row.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function fetchRequest(int $requestId): ?array
+    {
+        if ($requestId <= 0) {
+            return null;
+        }
+
+        $stmt = $this->conn->prepare('SELECT * FROM listing_change_requests WHERE id = ?');
+        if ($stmt === false) {
+            return null;
+        }
+
+        $stmt->bind_param('i', $requestId);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            return null;
+        }
+
+        $result = $stmt->get_result();
+        $row = $result ? $result->fetch_assoc() : null;
+        $stmt->close();
+
+        return $row ?: null;
     }
 
     private function resolveOpenRequests(

--- a/includes/repositories/ListingsRepo.php
+++ b/includes/repositories/ListingsRepo.php
@@ -1,4 +1,8 @@
 <?php
+/*
+ * Discovery note: Listings repository only handled status changes and tag updates.
+ * Change: Added critical field editing with moderation flows plus richer owner pagination metadata.
+ */
 declare(strict_types=1);
 
 require_once __DIR__ . '/ShopLogger.php';
@@ -252,6 +256,156 @@ final class ListingsRepo
     }
 
     /**
+     * Update core listing fields, falling back to moderation when required.
+     *
+     * @param array<string, mixed> $data
+     * @return array{success: bool, changed: bool, requires_review?: bool}
+     */
+    public function updateDetails(int $listingId, int $actorId, array $data, bool $isAdmin, bool $isOfficial): array
+    {
+        if ($listingId <= 0 || $actorId <= 0) {
+            return ['success' => false, 'changed' => false];
+        }
+
+        $this->conn->begin_transaction();
+        try {
+            $listing = $this->fetchListingDetails($listingId, true);
+            if (!$listing) {
+                throw new RuntimeException('Listing could not be found.');
+            }
+
+            $ownerId = (int) $listing['owner_id'];
+            $status = strtolower((string) $listing['status']);
+            $isOwner = $ownerId === $actorId;
+
+            if (!$isOwner && !$isAdmin && !$isOfficial) {
+                throw new RuntimeException('You do not have permission to edit this listing.');
+            }
+
+            $changes = [];
+
+            if (array_key_exists('title', $data)) {
+                $title = trim((string) $data['title']);
+                if ($title !== '' && $title !== (string) $listing['title']) {
+                    $changes['title'] = $title;
+                }
+            }
+
+            if (array_key_exists('price', $data)) {
+                $priceInput = trim((string) $data['price']);
+                if ($priceInput !== '') {
+                    if (!preg_match('/^\d+(?:\.\d{1,2})?$/', $priceInput)) {
+                        throw new RuntimeException('Prices must be numeric with up to two decimals.');
+                    }
+                    $normalisedPrice = number_format((float) $priceInput, 2, '.', '');
+                    $currentPrice = number_format((float) $listing['price'], 2, '.', '');
+                    if ($normalisedPrice !== $currentPrice) {
+                        $changes['price'] = $normalisedPrice;
+                    }
+                }
+            }
+
+            if (array_key_exists('quantity', $data)) {
+                $quantityInput = trim((string) $data['quantity']);
+                if ($quantityInput !== '') {
+                    if (!preg_match('/^\d+$/', $quantityInput)) {
+                        throw new RuntimeException('Quantity must be a whole number.');
+                    }
+                    $nextQuantity = max(0, (int) $quantityInput);
+                    $currentQuantity = isset($listing['quantity']) ? (int) $listing['quantity'] : null;
+                    if ($currentQuantity === null || $nextQuantity !== $currentQuantity) {
+                        $changes['quantity'] = $nextQuantity;
+                    }
+                }
+            }
+
+            if ($changes === []) {
+                $this->conn->rollback();
+                return ['success' => true, 'changed' => false];
+            }
+
+            if ($status === 'live' && !$isAdmin && !$isOfficial) {
+                $this->conn->rollback();
+                $summary = 'Critical update requested: ' . implode(', ', array_keys($changes));
+                $this->changeRequests->createCriticalUpdateRequest($listingId, $actorId, $changes, $summary);
+
+                return ['success' => true, 'changed' => false, 'requires_review' => true];
+            }
+
+            $set = [];
+            $types = '';
+            $params = [];
+
+            if (isset($changes['title'])) {
+                $set[] = 'title = ?';
+                $types .= 's';
+                $params[] = $changes['title'];
+            }
+
+            if (isset($changes['price'])) {
+                $set[] = 'price = ?';
+                $types .= 's';
+                $params[] = $changes['price'];
+            }
+
+            if (array_key_exists('quantity', $changes)) {
+                $set[] = 'quantity = ?';
+                $types .= 'i';
+                $params[] = $changes['quantity'];
+            }
+
+            $set[] = 'updated_at = NOW()';
+            $sql = 'UPDATE listings SET ' . implode(', ', $set) . ' WHERE id = ?';
+            $types .= 'i';
+            $params[] = $listingId;
+
+            $stmt = $this->conn->prepare($sql);
+            if ($stmt === false) {
+                throw new RuntimeException('Unable to prepare listing update.');
+            }
+
+            $stmt->bind_param($types, ...$params);
+            if (!$stmt->execute()) {
+                $stmt->close();
+                throw new RuntimeException('Failed to update the listing.');
+            }
+
+            $changed = $stmt->affected_rows > 0;
+            $stmt->close();
+
+            if ($changed && array_key_exists('quantity', $changes)) {
+                $guard = $this->conn->prepare('UPDATE listings SET reserved_qty = LEAST(reserved_qty, quantity) WHERE id = ?');
+                if ($guard !== false) {
+                    $guard->bind_param('i', $listingId);
+                    $guard->execute();
+                    $guard->close();
+                }
+            }
+
+            $this->conn->commit();
+
+            if ($changed) {
+                shop_log('listing.details_updated', [
+                    'listing_id' => $listingId,
+                    'actor_id' => $actorId,
+                    'fields' => array_keys($changes),
+                ]);
+            }
+
+            return ['success' => true, 'changed' => $changed];
+        } catch (Throwable $e) {
+            $this->conn->rollback();
+            shop_log('listing.update_error', [
+                'listing_id' => $listingId,
+                'actor_id' => $actorId,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    /**
      * Delete a listing owned by the actor.
      */
     public function delete(int $listingId, int $actorId, bool $isAdmin = false): array
@@ -290,6 +444,77 @@ final class ListingsRepo
         }
 
         return ['success' => $success, 'changed' => $changed];
+    }
+
+    /**
+     * Approve and apply a pending change request.
+     */
+    public function approveChangeRequest(int $requestId, int $reviewerId): void
+    {
+        if ($requestId <= 0 || $reviewerId <= 0) {
+            throw new RuntimeException('Invalid change request.');
+        }
+
+        $request = $this->changeRequests->fetchRequest($requestId);
+        if (!$request) {
+            throw new RuntimeException('Change request not found.');
+        }
+
+        if (($request['status'] ?? 'pending') !== 'pending') {
+            throw new RuntimeException('Change request has already been processed.');
+        }
+
+        $listingId = (int) $request['listing_id'];
+        $type = (string) ($request['change_type'] ?? 'status');
+
+        if ($type === 'critical_update') {
+            $payload = $request['payload'] ?? null;
+            $changes = [];
+            if ($payload !== null && $payload !== '') {
+                $decoded = json_decode((string) $payload, true);
+                if (is_array($decoded)) {
+                    $changes = $decoded;
+                }
+            }
+
+            if ($changes === []) {
+                $this->changeRequests->markSingleRequest($requestId, 'approved', $reviewerId);
+
+                return;
+            }
+
+            $result = $this->updateDetails($listingId, $reviewerId, $changes, true, true);
+            if (empty($result['success'])) {
+                throw new RuntimeException('Failed to apply the requested listing changes.');
+            }
+
+            $this->changeRequests->markSingleRequest($requestId, 'approved', $reviewerId);
+            shop_log('listing.change_request_approved', [
+                'request_id' => $requestId,
+                'listing_id' => $listingId,
+                'reviewer_id' => $reviewerId,
+                'fields' => array_keys($changes),
+            ]);
+
+            return;
+        }
+
+        if ($type === 'status') {
+            $requestedStatus = (string) ($request['requested_status'] ?? 'approved');
+            $this->updateStatus($listingId, $reviewerId, $requestedStatus, true);
+            $this->changeRequests->markSingleRequest($requestId, 'approved', $reviewerId, $requestedStatus);
+
+            shop_log('listing.change_request_approved', [
+                'request_id' => $requestId,
+                'listing_id' => $listingId,
+                'reviewer_id' => $reviewerId,
+                'status' => $requestedStatus,
+            ]);
+
+            return;
+        }
+
+        $this->changeRequests->markSingleRequest($requestId, 'approved', $reviewerId);
     }
 
     /**
@@ -342,7 +567,11 @@ final class ListingsRepo
         $items = [];
 
         $select = 'SELECT l.id, l.title, l.price, l.category, l.tags, l.image, l.status, l.pickup_only, l.created_at, '
-            . 'l.updated_at, l.quantity, l.reserved_qty';
+            . 'l.updated_at, l.quantity, l.reserved_qty, l.is_official_listing, '
+            . '(SELECT COUNT(*) FROM listing_change_requests r WHERE r.listing_id = l.id AND r.status = "pending") '
+            . 'AS pending_change_count, '
+            . '(SELECT MAX(r.change_summary) FROM listing_change_requests r WHERE r.listing_id = l.id '
+            . 'AND r.status = "pending") AS pending_change_summary';
 
         if ($withSyncState) {
             $select .= ', scm.sync_status AS square_sync_status, scm.square_object_id AS square_object_id';
@@ -380,6 +609,9 @@ final class ListingsRepo
                             'image' => $row['image'],
                             'square_sync_status' => $row['square_sync_status'] ?? null,
                             'square_object_id' => $row['square_object_id'] ?? null,
+                            'is_official_listing' => !empty($row['is_official_listing']),
+                            'pending_change' => ((int) ($row['pending_change_count'] ?? 0)) > 0,
+                            'pending_change_summary' => $row['pending_change_summary'] ?? null,
                         ];
                     }
                 }
@@ -416,6 +648,36 @@ final class ListingsRepo
         }
 
         $sql = 'SELECT id, owner_id, status, quantity, reserved_qty, product_sku FROM listings WHERE id = ?';
+        if ($forUpdate) {
+            $sql .= ' FOR UPDATE';
+        }
+
+        $stmt = $this->conn->prepare($sql);
+        if ($stmt === false) {
+            return null;
+        }
+
+        $stmt->bind_param('i', $listingId);
+        if (!$stmt->execute()) {
+            $stmt->close();
+            return null;
+        }
+
+        $result = $stmt->get_result();
+        $row = $result ? $result->fetch_assoc() : null;
+        $stmt->close();
+
+        return $row ?: null;
+    }
+
+    /**
+     * Fetch listing details for critical updates.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function fetchListingDetails(int $listingId, bool $forUpdate = false): ?array
+    {
+        $sql = 'SELECT id, owner_id, status, title, price, quantity, reserved_qty FROM listings WHERE id = ?';
         if ($forUpdate) {
             $sql .= ' FOR UPDATE';
         }

--- a/includes/repositories/ShopLogger.php
+++ b/includes/repositories/ShopLogger.php
@@ -1,4 +1,8 @@
 <?php
+/*
+ * Discovery note: Shared shop logger lacked the discovery/change header and context.
+ * Change: Documented the helper so future updates know it centralises structured auditing.
+ */
 declare(strict_types=1);
 
 /**

--- a/includes/repositories/SquareCatalogSync.php
+++ b/includes/repositories/SquareCatalogSync.php
@@ -1,4 +1,10 @@
 <?php
+/*
+ * Discovery note: Square catalog sync helper was wired to an obsolete config flag
+ * and lacked documentation.
+ * Change: Documented the helper and aligned enablement with the new SQUARE_SYNC
+ * feature flags so the manager UI honours the toggle.
+ */
 declare(strict_types=1);
 
 require_once __DIR__ . '/ShopLogger.php';
@@ -11,7 +17,7 @@ final class SquareCatalogSync
     public function __construct(mysqli $conn, array $config)
     {
         $this->conn = $conn;
-        $this->enabled = !empty($config['SQUARE_CATALOG_SYNC']) && $this->tableExists();
+        $this->enabled = !empty($config['SQUARE_SYNC_ENABLED']) && $this->tableExists();
     }
 
     public function isEnabled(): bool

--- a/includes/shop_manager.php
+++ b/includes/shop_manager.php
@@ -1,4 +1,8 @@
 <?php
+/*
+ * Discovery note: Shop manager tabs previously omitted a dedicated sync panel for catalog ops.
+ * Change: Added a Sync tab definition to surface manual Square reconciliations.
+ */
 
 declare(strict_types=1);
 
@@ -26,6 +30,10 @@ const SHOP_MANAGER_TABS = [
     'settings' => [
         'label' => 'Settings',
         'description' => 'Configure default preferences for your shop.',
+    ],
+    'sync' => [
+        'label' => 'Sync',
+        'description' => 'Manage catalog synchronisation with Square.',
     ],
 ];
 

--- a/includes/square-log.php
+++ b/includes/square-log.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Discovery note: Existing logging lived in repositories/ShopLogger with plain text output.
+ * Change: Added Square-specific helper writing to logs/square.log with sensitive keys scrubbed.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Write a sanitized entry to the Square integration log.
+ */
+function square_log(string $event, array $context = []): void
+{
+    $logDir = dirname(__DIR__) . '/logs';
+    $file = $logDir . '/square.log';
+
+    if (!is_dir($logDir)) {
+        mkdir($logDir, 0775, true);
+    }
+
+    $scrubbed = [];
+    foreach ($context as $key => $value) {
+        $normalized = is_string($key) ? strtolower($key) : '';
+        if ($normalized !== '' && preg_match('/token|secret|key|password/', $normalized)) {
+            $scrubbed[$key] = '[redacted]';
+            continue;
+        }
+        if (is_scalar($value) || $value === null) {
+            $scrubbed[$key] = $value;
+        } else {
+            $encoded = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $scrubbed[$key] = $encoded !== false ? $encoded : '[unserializable]';
+        }
+    }
+
+    $payload = $scrubbed ? json_encode($scrubbed, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : '';
+    if ($payload === false) {
+        $payload = '';
+    }
+
+    $line = sprintf('[%s] %s%s', date('Y-m-d H:i:s'), $event, $payload !== '' ? ' ' . $payload : '');
+
+    file_put_contents($file, $line . PHP_EOL, FILE_APPEND | LOCK_EX);
+}

--- a/includes/square-migrations.php
+++ b/includes/square-migrations.php
@@ -1,0 +1,605 @@
+<?php
+/*
+ * Discovery note: Square sync tables existed only as raw SQL files without runtime guards.
+ * Change: Added idempotent PHP migrations with logging so admin tools can self-heal schema,
+ *         expanded coverage to the commerce tables needed for orders, inventory, catalog
+ *         linkage, and now provision webhook idempotency storage for processed events.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/square-log.php';
+
+/**
+ * Run lightweight Square migrations in a way that is safe to call repeatedly.
+ */
+function square_run_migrations(mysqli $conn): void
+{
+    $database = square_migration_database_name($conn);
+    if ($database === null) {
+        square_log('square.migration', [
+            'migration' => 'bootstrap',
+            'status' => 'skipped',
+            'reason' => 'no_database_selected',
+        ]);
+        return;
+    }
+
+    $supportsJson = square_mysql_supports_json($conn);
+    $jsonType = $supportsJson ? 'JSON' : 'TEXT';
+
+    square_ensure_sync_state_table($conn, $jsonType);
+    square_ensure_sync_errors_table($conn, $jsonType);
+    square_ensure_user_shipping_profiles_table($conn);
+    square_ensure_order_items_table($conn);
+    square_ensure_inventory_transactions_table($conn, $jsonType);
+    square_ensure_listing_change_requests_table($conn, $jsonType);
+    square_ensure_product_modifiers_table($conn, $jsonType);
+    square_ensure_processed_events_table($conn);
+    square_ensure_order_fulfillments_columns($conn);
+    square_ensure_square_catalog_map_indexes($conn);
+}
+
+function square_ensure_sync_state_table(mysqli $conn, string $jsonType): void
+{
+    $table = 'square_sync_state';
+
+    if (!square_table_exists($conn, $table)) {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS {$table} (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    setting_key VARCHAR(64) NOT NULL UNIQUE,
+    last_synced_at DATETIME NULL,
+    last_webhook_at DATETIME NULL,
+    sync_direction VARCHAR(16) NOT NULL DEFAULT 'pull',
+    metadata {$jsonType} NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL;
+        square_run_statement($conn, $sql, $table . '.create_table');
+    } else {
+        square_log('square.migration', [
+            'migration' => $table . '.create_table',
+            'status' => 'skipped',
+            'reason' => 'exists',
+        ]);
+    }
+
+    square_ensure_column($conn, $table, 'last_synced_at', 'DATETIME NULL', $table . '.last_synced_at');
+    square_ensure_column($conn, $table, 'last_webhook_at', 'DATETIME NULL', $table . '.last_webhook_at');
+    square_ensure_column($conn, $table, 'sync_direction', "VARCHAR(16) NOT NULL DEFAULT 'pull'", $table . '.sync_direction');
+    square_ensure_column($conn, $table, 'metadata', $jsonType . ' NULL', $table . '.metadata');
+}
+
+function square_ensure_sync_errors_table(mysqli $conn, string $jsonType): void
+{
+    $table = 'square_sync_errors';
+
+    if (!square_table_exists($conn, $table)) {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS {$table} (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    error_code VARCHAR(64) NULL,
+    message TEXT NOT NULL,
+    context {$jsonType} NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX ({created_at})
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL;
+        // Replace the placeholder index syntax for portability
+        $sql = str_replace('{created_at}', '`created_at`', $sql);
+        square_run_statement($conn, $sql, $table . '.create_table');
+    } else {
+        square_log('square.migration', [
+            'migration' => $table . '.create_table',
+            'status' => 'skipped',
+            'reason' => 'exists',
+        ]);
+    }
+
+    square_ensure_column($conn, $table, 'error_code', 'VARCHAR(64) NULL', $table . '.error_code');
+    square_ensure_column($conn, $table, 'message', 'TEXT NOT NULL', $table . '.message');
+    square_ensure_column($conn, $table, 'context', $jsonType . ' NULL', $table . '.context');
+    square_ensure_index($conn, $table, 'created_at', 'created_at');
+}
+
+function square_ensure_order_items_table(mysqli $conn): void
+{
+    $table = 'order_items';
+
+    if (!square_table_exists($conn, $table)) {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS {$table} (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    payment_id INT NULL,
+    order_id VARCHAR(64) NULL,
+    product_sku VARCHAR(64) NULL,
+    listing_id INT NULL,
+    quantity INT NOT NULL DEFAULT 1,
+    unit_price DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+    modifiers TEXT NULL,
+    subtotal DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL;
+        square_run_statement($conn, $sql, $table . '.create_table');
+    } else {
+        square_log('square.migration', [
+            'migration' => $table . '.create_table',
+            'status' => 'skipped',
+            'reason' => 'exists',
+        ]);
+    }
+
+    square_ensure_column($conn, $table, 'payment_id', 'INT NULL', $table . '.payment_id');
+    square_ensure_column($conn, $table, 'order_id', 'VARCHAR(64) NULL', $table . '.order_id');
+    square_ensure_column($conn, $table, 'product_sku', 'VARCHAR(64) NULL', $table . '.product_sku');
+    square_ensure_column($conn, $table, 'listing_id', 'INT NULL', $table . '.listing_id');
+    square_ensure_column($conn, $table, 'quantity', 'INT NOT NULL DEFAULT 1', $table . '.quantity');
+    square_ensure_column($conn, $table, 'unit_price', 'DECIMAL(10,2) NOT NULL DEFAULT 0.00', $table . '.unit_price');
+    square_ensure_column($conn, $table, 'modifiers', 'TEXT NULL', $table . '.modifiers');
+    square_ensure_column($conn, $table, 'subtotal', 'DECIMAL(10,2) NOT NULL DEFAULT 0.00', $table . '.subtotal');
+    square_ensure_column($conn, $table, 'created_at', 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP', $table . '.created_at');
+
+    square_ensure_index($conn, $table, 'payment_id', 'idx_order_items_payment_id');
+    square_ensure_index($conn, $table, 'order_id', 'idx_order_items_order_id');
+    square_ensure_index($conn, $table, 'product_sku', 'idx_order_items_product_sku');
+    square_ensure_index($conn, $table, 'listing_id', 'idx_order_items_listing_id');
+}
+
+function square_ensure_inventory_transactions_table(mysqli $conn, string $jsonType): void
+{
+    $table = 'inventory_transactions';
+
+    if (!square_table_exists($conn, $table)) {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS {$table} (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    product_sku VARCHAR(64) NOT NULL,
+    owner_id INT NOT NULL,
+    transaction_type VARCHAR(32) NOT NULL,
+    quantity_change INT NOT NULL,
+    quantity_before INT NULL,
+    quantity_after INT NULL,
+    reference_type VARCHAR(32) NULL,
+    reference_id BIGINT NULL,
+    metadata {$jsonType} NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_inventory_transactions_product FOREIGN KEY (product_sku) REFERENCES products(sku) ON DELETE CASCADE,
+    CONSTRAINT fk_inventory_transactions_owner FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL;
+        square_run_statement($conn, $sql, $table . '.create_table');
+    } else {
+        square_log('square.migration', [
+            'migration' => $table . '.create_table',
+            'status' => 'skipped',
+            'reason' => 'exists',
+        ]);
+    }
+
+    square_ensure_column($conn, $table, 'product_sku', 'VARCHAR(64) NOT NULL', $table . '.product_sku');
+    square_ensure_column($conn, $table, 'owner_id', 'INT NOT NULL', $table . '.owner_id');
+    square_ensure_column($conn, $table, 'transaction_type', 'VARCHAR(32) NOT NULL', $table . '.transaction_type');
+    square_ensure_column($conn, $table, 'quantity_change', 'INT NOT NULL', $table . '.quantity_change');
+    square_ensure_column($conn, $table, 'quantity_before', 'INT NULL', $table . '.quantity_before');
+    square_ensure_column($conn, $table, 'quantity_after', 'INT NULL', $table . '.quantity_after');
+    square_ensure_column($conn, $table, 'reference_type', 'VARCHAR(32) NULL', $table . '.reference_type');
+    square_ensure_column($conn, $table, 'reference_id', 'BIGINT NULL', $table . '.reference_id');
+    square_ensure_column($conn, $table, 'metadata', $jsonType . ' NULL', $table . '.metadata');
+    square_ensure_column($conn, $table, 'created_at', 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP', $table . '.created_at');
+
+    square_ensure_index($conn, $table, 'product_sku', 'idx_inventory_transactions_product');
+    square_ensure_index($conn, $table, 'owner_id', 'idx_inventory_transactions_owner');
+    square_ensure_composite_index($conn, $table, 'idx_inventory_transactions_reference', ['reference_type', 'reference_id']);
+}
+
+function square_ensure_order_fulfillments_columns(mysqli $conn): void
+{
+    $table = 'order_fulfillments';
+    if (!square_table_exists($conn, $table)) {
+        square_log('square.migration', [
+            'migration' => $table . '.columns',
+            'status' => 'skipped',
+            'reason' => 'table_missing',
+        ]);
+        return;
+    }
+
+    square_ensure_column($conn, $table, 'shipping_profile_id', 'INT NULL', $table . '.shipping_profile_id');
+    square_ensure_column($conn, $table, 'shipping_snapshot', 'TEXT NULL', $table . '.shipping_snapshot');
+    square_ensure_column($conn, $table, 'status', "VARCHAR(50) NOT NULL DEFAULT 'pending'", $table . '.status');
+    square_ensure_column($conn, $table, 'tracking_number', 'VARCHAR(100) NULL', $table . '.tracking_number');
+    square_ensure_column($conn, $table, 'updated_at', 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $table . '.updated_at');
+
+    if (square_table_exists($conn, 'user_shipping_profiles')) {
+        square_ensure_foreign_key(
+            $conn,
+            $table,
+            'fk_order_fulfillments_shipping_profile',
+            'FOREIGN KEY (`shipping_profile_id`) REFERENCES `user_shipping_profiles`(`id`)'
+        );
+    }
+}
+
+function square_ensure_user_shipping_profiles_table(mysqli $conn): void
+{
+    $table = 'user_shipping_profiles';
+
+    if (!square_table_exists($conn, $table)) {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS {$table} (
+    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    label VARCHAR(100) NOT NULL,
+    recipient_name VARCHAR(255) NOT NULL,
+    address_line1 VARCHAR(255) NOT NULL,
+    address_line2 VARCHAR(255) NULL,
+    city VARCHAR(100) NOT NULL,
+    region VARCHAR(100) NOT NULL,
+    postal_code VARCHAR(20) NOT NULL,
+    country VARCHAR(2) NOT NULL DEFAULT 'US',
+    phone VARCHAR(30) NULL,
+    is_default TINYINT(1) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_user_shipping_profiles_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL;
+        square_run_statement($conn, $sql, $table . '.create_table');
+    } else {
+        square_log('square.migration', [
+            'migration' => $table . '.create_table',
+            'status' => 'skipped',
+            'reason' => 'exists',
+        ]);
+    }
+
+    square_ensure_column($conn, $table, 'user_id', 'INT NOT NULL', $table . '.user_id');
+    square_ensure_column($conn, $table, 'label', 'VARCHAR(100) NOT NULL', $table . '.label');
+    square_ensure_column($conn, $table, 'recipient_name', 'VARCHAR(255) NOT NULL', $table . '.recipient_name');
+    square_ensure_column($conn, $table, 'address_line1', 'VARCHAR(255) NOT NULL', $table . '.address_line1');
+    square_ensure_column($conn, $table, 'address_line2', 'VARCHAR(255) NULL', $table . '.address_line2');
+    square_ensure_column($conn, $table, 'city', 'VARCHAR(100) NOT NULL', $table . '.city');
+    square_ensure_column($conn, $table, 'region', 'VARCHAR(100) NOT NULL', $table . '.region');
+    square_ensure_column($conn, $table, 'postal_code', 'VARCHAR(20) NOT NULL', $table . '.postal_code');
+    square_ensure_column($conn, $table, 'country', "VARCHAR(2) NOT NULL DEFAULT 'US'", $table . '.country');
+    square_ensure_column($conn, $table, 'phone', 'VARCHAR(30) NULL', $table . '.phone');
+    square_ensure_column($conn, $table, 'is_default', 'TINYINT(1) NOT NULL DEFAULT 0', $table . '.is_default');
+    square_ensure_column($conn, $table, 'created_at', 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP', $table . '.created_at');
+    square_ensure_column($conn, $table, 'updated_at', 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $table . '.updated_at');
+
+    square_ensure_index($conn, $table, 'user_id', 'idx_user_shipping_profiles_user_id');
+}
+
+function square_ensure_listing_change_requests_table(mysqli $conn, string $jsonType): void
+{
+    $table = 'listing_change_requests';
+
+    if (!square_table_exists($conn, $table)) {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS {$table} (
+    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    listing_id INT NOT NULL,
+    requester_id INT NOT NULL,
+    reviewer_id INT NULL,
+    change_type VARCHAR(32) NOT NULL DEFAULT 'status',
+    change_summary TEXT NULL,
+    requested_status ENUM('draft','pending','approved','live','closed','delisted') NULL,
+    payload {$jsonType} NULL,
+    status ENUM('pending','approved','rejected','cancelled') NOT NULL DEFAULT 'pending',
+    review_notes TEXT NULL,
+    resolved_at TIMESTAMP NULL DEFAULT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_listing_change_requests_listing FOREIGN KEY (listing_id) REFERENCES listings(id) ON DELETE CASCADE,
+    CONSTRAINT fk_listing_change_requests_requester FOREIGN KEY (requester_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_listing_change_requests_reviewer FOREIGN KEY (reviewer_id) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL;
+        square_run_statement($conn, $sql, $table . '.create_table');
+    } else {
+        square_log('square.migration', [
+            'migration' => $table . '.create_table',
+            'status' => 'skipped',
+            'reason' => 'exists',
+        ]);
+    }
+
+    square_ensure_column($conn, $table, 'listing_id', 'INT NOT NULL', $table . '.listing_id');
+    square_ensure_column($conn, $table, 'requester_id', 'INT NOT NULL', $table . '.requester_id');
+    square_ensure_column($conn, $table, 'reviewer_id', 'INT NULL', $table . '.reviewer_id');
+    square_ensure_column($conn, $table, 'change_type', "VARCHAR(32) NOT NULL DEFAULT 'status'", $table . '.change_type');
+    square_ensure_column($conn, $table, 'change_summary', 'TEXT NULL', $table . '.change_summary');
+    square_ensure_column($conn, $table, 'requested_status', "ENUM('draft','pending','approved','live','closed','delisted') NULL", $table . '.requested_status');
+    square_ensure_column($conn, $table, 'payload', $jsonType . ' NULL', $table . '.payload');
+    square_ensure_column($conn, $table, 'status', "ENUM('pending','approved','rejected','cancelled') NOT NULL DEFAULT 'pending'", $table . '.status');
+    square_ensure_column($conn, $table, 'review_notes', 'TEXT NULL', $table . '.review_notes');
+    square_ensure_column($conn, $table, 'resolved_at', 'TIMESTAMP NULL DEFAULT NULL', $table . '.resolved_at');
+    square_ensure_column($conn, $table, 'created_at', 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP', $table . '.created_at');
+    square_ensure_column($conn, $table, 'updated_at', 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $table . '.updated_at');
+
+    square_ensure_index($conn, $table, 'listing_id', 'idx_listing_change_requests_listing_id');
+    square_ensure_index($conn, $table, 'requester_id', 'idx_listing_change_requests_requester_id');
+    square_ensure_index($conn, $table, 'reviewer_id', 'idx_listing_change_requests_reviewer_id');
+    square_ensure_composite_index($conn, $table, 'idx_listing_change_requests_listing_status', ['listing_id', 'status']);
+}
+
+function square_ensure_product_modifiers_table(mysqli $conn, string $jsonType): void
+{
+    $table = 'product_modifiers';
+
+    if (!square_table_exists($conn, $table)) {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS {$table} (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    product_sku VARCHAR(64) NOT NULL,
+    square_modifier_list_id VARCHAR(255) NULL,
+    data {$jsonType} NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_product_modifiers_product FOREIGN KEY (product_sku) REFERENCES products(sku) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL;
+        square_run_statement($conn, $sql, $table . '.create_table');
+    } else {
+        square_log('square.migration', [
+            'migration' => $table . '.create_table',
+            'status' => 'skipped',
+            'reason' => 'exists',
+        ]);
+    }
+
+    square_ensure_column($conn, $table, 'product_sku', 'VARCHAR(64) NOT NULL', $table . '.product_sku');
+    square_ensure_column($conn, $table, 'square_modifier_list_id', 'VARCHAR(255) NULL', $table . '.square_modifier_list_id');
+    square_ensure_column($conn, $table, 'data', $jsonType . ' NULL', $table . '.data');
+    square_ensure_column($conn, $table, 'created_at', 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP', $table . '.created_at');
+    square_ensure_column($conn, $table, 'updated_at', 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $table . '.updated_at');
+
+    square_ensure_index($conn, $table, 'product_sku', 'idx_product_modifiers_product_sku');
+    square_ensure_composite_index($conn, $table, 'uniq_product_modifiers_product_sku', ['product_sku'], true);
+}
+
+function square_ensure_processed_events_table(mysqli $conn): void
+{
+    $table = 'square_processed_events';
+
+    if (!square_table_exists($conn, $table)) {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS {$table} (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    event_id VARCHAR(255) NOT NULL,
+    event_type VARCHAR(64) NULL,
+    received_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_square_processed_event_id (event_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL;
+        square_run_statement($conn, $sql, $table . '.create_table');
+    } else {
+        square_log('square.migration', [
+            'migration' => $table . '.create_table',
+            'status' => 'skipped',
+            'reason' => 'exists',
+        ]);
+    }
+
+    square_ensure_column($conn, $table, 'event_type', 'VARCHAR(64) NULL', $table . '.event_type');
+    square_ensure_column($conn, $table, 'received_at', 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP', $table . '.received_at');
+    square_ensure_composite_index($conn, $table, 'uniq_square_processed_event_id', ['event_id'], true);
+}
+
+function square_ensure_square_catalog_map_indexes(mysqli $conn): void
+{
+    $table = 'square_catalog_map';
+    if (!square_table_exists($conn, $table)) {
+        square_log('square.migration', [
+            'migration' => $table . '.indexes',
+            'status' => 'skipped',
+            'reason' => 'table_missing',
+        ]);
+        return;
+    }
+
+    square_ensure_composite_index($conn, $table, 'uniq_square_catalog_map_local', ['local_type', 'local_id'], true);
+    square_ensure_composite_index($conn, $table, 'uniq_square_catalog_map_square', ['square_object_id'], true);
+}
+
+function square_run_statement(mysqli $conn, string $sql, string $migration): void
+{
+    try {
+        $conn->query($sql);
+        square_log('square.migration', [
+            'migration' => $migration,
+            'status' => 'applied',
+        ]);
+    } catch (Throwable $e) {
+        square_log('square.migration_error', [
+            'migration' => $migration,
+            'status' => 'failed',
+            'error' => $e->getMessage(),
+        ]);
+    }
+}
+
+function square_migration_database_name(mysqli $conn): ?string
+{
+    $result = $conn->query('SELECT DATABASE() AS db');
+    if ($result instanceof mysqli_result) {
+        $row = $result->fetch_assoc();
+        $result->free();
+        if ($row && !empty($row['db'])) {
+            return (string) $row['db'];
+        }
+    }
+
+    return null;
+}
+
+function square_table_exists(mysqli $conn, string $table): bool
+{
+    $stmt = $conn->prepare('SHOW TABLES LIKE ?');
+    if ($stmt === false) {
+        return false;
+    }
+
+    $stmt->bind_param('s', $table);
+    $stmt->execute();
+    $stmt->store_result();
+    $exists = $stmt->num_rows > 0;
+    $stmt->close();
+
+    return $exists;
+}
+
+function square_column_exists(mysqli $conn, string $table, string $column): bool
+{
+    $stmt = $conn->prepare('SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?');
+    if ($stmt === false) {
+        return false;
+    }
+
+    $stmt->bind_param('ss', $table, $column);
+    $stmt->execute();
+    $stmt->bind_result($count);
+    $stmt->fetch();
+    $stmt->close();
+
+    return (int) $count > 0;
+}
+
+function square_index_exists(mysqli $conn, string $table, string $index): bool
+{
+    $stmt = $conn->prepare('SHOW INDEX FROM `' . $conn->real_escape_string($table) . '` WHERE Key_name = ?');
+    if ($stmt === false) {
+        return false;
+    }
+
+    $stmt->bind_param('s', $index);
+    $stmt->execute();
+    $stmt->store_result();
+    $exists = $stmt->num_rows > 0;
+    $stmt->close();
+
+    return $exists;
+}
+
+function square_foreign_key_exists(mysqli $conn, string $table, string $constraint): bool
+{
+    $sql = 'SELECT COUNT(*) FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = ? AND CONSTRAINT_NAME = ?';
+    $stmt = $conn->prepare($sql);
+    if ($stmt === false) {
+        return false;
+    }
+
+    $stmt->bind_param('ss', $table, $constraint);
+    $stmt->execute();
+    $stmt->bind_result($count);
+    $stmt->fetch();
+    $stmt->close();
+
+    return (int) $count > 0;
+}
+
+function square_ensure_foreign_key(mysqli $conn, string $table, string $constraint, string $definition): void
+{
+    if (square_foreign_key_exists($conn, $table, $constraint)) {
+        square_log('square.migration', [
+            'migration' => $table . '.fk.' . $constraint,
+            'status' => 'skipped',
+            'reason' => 'foreign_key_exists',
+        ]);
+        return;
+    }
+
+    $sql = sprintf('ALTER TABLE `%s` ADD CONSTRAINT `%s` %s', $table, $constraint, $definition);
+    square_run_statement($conn, $sql, $table . '.fk.' . $constraint);
+}
+
+function square_ensure_column(mysqli $conn, string $table, string $column, string $definition, string $migration): void
+{
+    if (square_column_exists($conn, $table, $column)) {
+        square_log('square.migration', [
+            'migration' => $migration,
+            'status' => 'skipped',
+            'reason' => 'column_exists',
+        ]);
+        return;
+    }
+
+    $sql = sprintf('ALTER TABLE `%s` ADD COLUMN `%s` %s', $table, $column, $definition);
+    square_run_statement($conn, $sql, $migration);
+}
+
+function square_ensure_index(mysqli $conn, string $table, string $column, string $index): void
+{
+    if (square_index_exists($conn, $table, $index)) {
+        square_log('square.migration', [
+            'migration' => $table . '.index.' . $index,
+            'status' => 'skipped',
+            'reason' => 'index_exists',
+        ]);
+        return;
+    }
+
+    $sql = sprintf('ALTER TABLE `%s` ADD INDEX `%s` (`%s`)', $table, $index, $column);
+    square_run_statement($conn, $sql, $table . '.index.' . $index);
+}
+
+function square_ensure_composite_index(mysqli $conn, string $table, string $index, array $columns, bool $unique = false): void
+{
+    if (square_index_exists($conn, $table, $index)) {
+        square_log('square.migration', [
+            'migration' => $table . '.index.' . $index,
+            'status' => 'skipped',
+            'reason' => 'index_exists',
+        ]);
+        return;
+    }
+
+    $quotedColumns = array_map(static fn(string $column): string => sprintf('`%s`', $column), $columns);
+    $columnList = implode(', ', $quotedColumns);
+    $type = $unique ? 'UNIQUE INDEX' : 'INDEX';
+    $sql = sprintf('ALTER TABLE `%s` ADD %s `%s` (%s)', $table, $type, $index, $columnList);
+    square_run_statement($conn, $sql, $table . '.index.' . $index);
+}
+
+function square_mysql_supports_json(mysqli $conn): bool
+{
+    $version = mysqli_get_server_version($conn);
+    if ($version <= 0) {
+        return false;
+    }
+
+    // MySQL 5.7.8+ and MariaDB 10.2.7+ have JSON support; MariaDB uses 10.x numbering (first two digits major*10000)
+    $major = (int) floor($version / 10000);
+    $minor = (int) floor(($version % 10000) / 100);
+    $patch = (int) ($version % 100);
+
+    // MySQL 8.x or newer definitely supports JSON
+    if ($major >= 8) {
+        return true;
+    }
+
+    // MySQL 5.7.8+
+    if ($major === 5) {
+        if ($minor > 7) {
+            return true;
+        }
+        if ($minor === 7 && $patch >= 8) {
+            return true;
+        }
+    }
+
+    // MariaDB 10.2.7+
+    if ($major >= 10) {
+        if ($minor > 2) {
+            return true;
+        }
+        if ($minor === 2 && $patch >= 7) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/shop-manager/sync.php
+++ b/shop-manager/sync.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Discovery note: The manager workspace surfaced sync status text but offered no manual trigger.
+ * Change: Added a Sync panel with a guarded "Sync Now" action for admins to call Square pull jobs.
+ */
+
+$syncActive = $activeTab === 'sync';
+$syncPanelId = 'shop-manager-panel-sync';
+$syncTabId = 'shop-manager-tab-sync';
+$syncDirectionLabel = strtoupper($squareSyncDirection ?? 'pull');
+?>
+<section
+  id="<?= htmlspecialchars($syncPanelId, ENT_QUOTES, 'UTF-8'); ?>"
+  class="store__panel<?= $syncActive ? ' is-active' : ''; ?>"
+  role="tabpanel"
+  aria-labelledby="<?= htmlspecialchars($syncTabId, ENT_QUOTES, 'UTF-8'); ?>"
+  data-manager-panel="sync"
+  <?= $syncActive ? '' : 'hidden'; ?>
+>
+  <header class="manager-panel__header">
+    <div>
+      <h3 class="manager-panel__title">Square Sync</h3>
+      <p class="manager-panel__description">
+        Pull the latest Square catalog and inventory counts to keep listings aligned.
+      </p>
+    </div>
+  </header>
+
+  <?php if (!$squareSyncAvailable): ?>
+    <div class="notice notice--info">
+      <p>Square sync is currently disabled. Enable the feature flag in configuration to activate manual sync.</p>
+    </div>
+  <?php else: ?>
+    <form method="post" class="manager-sync" data-manager-form>
+      <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
+      <input type="hidden" name="tab" value="sync">
+      <input type="hidden" name="manager_action" value="square_sync_now">
+
+      <p class="field-hint">
+        Current sync direction: <strong><?= htmlspecialchars($syncDirectionLabel, ENT_QUOTES, 'UTF-8'); ?></strong>.
+        Manual runs will pull catalog data and inventory counts; they will not delete any Square objects.
+      </p>
+
+      <button type="submit" class="btn btn--primary">Sync Now</button>
+    </form>
+  <?php endif; ?>
+</section>

--- a/webhooks/square.php
+++ b/webhooks/square.php
@@ -1,0 +1,453 @@
+<?php
+/*
+ * Discovery note: The application received Square callbacks without any verification or
+ * persistence, leaving payments and inventory out of sync.
+ * Change: Added a webhook endpoint that verifies signatures, de-duplicates events, and updates
+ *         payments, orders, and inventory while logging sync health.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/square-log.php';
+require_once __DIR__ . '/../includes/square-migrations.php';
+require_once __DIR__ . '/../includes/repositories/InventoryService.php';
+
+$config = require __DIR__ . '/../config.php';
+/** @var mysqli $conn */
+$conn = require __DIR__ . '/../includes/db.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    header('Allow: POST');
+    echo json_encode(['error' => 'method_not_allowed']);
+    exit;
+}
+
+square_run_migrations($conn);
+
+$body = file_get_contents('php://input');
+if ($body === false) {
+    $body = '';
+}
+
+$secret = trim((string) ($config['square_webhook_signature_key'] ?? ''));
+$signature = (string) ($_SERVER['HTTP_X_SQUARE_SIGNATURE'] ?? '');
+
+if ($secret !== '') {
+    $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+    $host = $_SERVER['HTTP_HOST'] ?? ($_SERVER['SERVER_NAME'] ?? '');
+    $uri = $_SERVER['REQUEST_URI'] ?? '/webhooks/square.php';
+    $notificationUrl = $scheme . '://' . $host . $uri;
+    $computed = base64_encode(hash_hmac('sha1', $notificationUrl . $body, $secret, true));
+    if (!hash_equals($computed, $signature)) {
+        square_log('square.webhook_signature_invalid', [
+            'notification_url' => $notificationUrl,
+        ]);
+        http_response_code(400);
+        echo json_encode(['error' => 'invalid_signature']);
+        exit;
+    }
+} else {
+    square_log('square.webhook_signature_missing', []);
+}
+
+$payload = json_decode($body, true);
+if (!is_array($payload)) {
+    square_log('square.webhook_invalid_payload', []);
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid_payload']);
+    exit;
+}
+
+$eventId = (string) ($payload['event_id'] ?? '');
+$eventType = (string) ($payload['type'] ?? '');
+
+if ($eventId === '' || $eventType === '') {
+    square_log('square.webhook_missing_event', ['payload' => $payload]);
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid_event']);
+    exit;
+}
+
+if (!square_webhook_mark_processed($conn, $eventId, $eventType)) {
+    square_log('square.webhook_duplicate', ['event_id' => $eventId, 'type' => $eventType]);
+    http_response_code(200);
+    echo json_encode(['status' => 'duplicate']);
+    exit;
+}
+
+try {
+    $handled = false;
+    switch ($eventType) {
+        case 'payment.updated':
+            $handled = square_webhook_handle_payment($conn, $payload);
+            break;
+        case 'order.updated':
+            $handled = square_webhook_handle_order($conn, $payload);
+            break;
+        case 'inventory.count.updated':
+            $handled = square_webhook_handle_inventory($conn, $payload);
+            break;
+        default:
+            square_log('square.webhook_unhandled', ['event_id' => $eventId, 'type' => $eventType]);
+            $handled = true;
+            break;
+    }
+
+    square_webhook_touch_state($conn, ['last_webhook_at' => date('Y-m-d H:i:s')]);
+
+    if ($handled) {
+        http_response_code(200);
+        echo json_encode(['status' => 'ok']);
+    } else {
+        http_response_code(202);
+        echo json_encode(['status' => 'ignored']);
+    }
+} catch (Throwable $e) {
+    square_log('square.webhook_exception', [
+        'event_id' => $eventId,
+        'type' => $eventType,
+        'error' => $e->getMessage(),
+    ]);
+    http_response_code(500);
+    echo json_encode(['error' => 'server_error']);
+}
+
+/**
+ * Persist the webhook event identifier for idempotency checks.
+ */
+function square_webhook_mark_processed(mysqli $conn, string $eventId, string $eventType): bool
+{
+    $stmt = $conn->prepare(
+        'INSERT INTO square_processed_events (event_id, event_type, received_at) VALUES (?, ?, NOW()) '
+        . 'ON DUPLICATE KEY UPDATE event_id = event_id'
+    );
+    if ($stmt === false) {
+        return true;
+    }
+
+    $stmt->bind_param('ss', $eventId, $eventType);
+    $stmt->execute();
+    $affected = $stmt->affected_rows;
+    $stmt->close();
+
+    return $affected === 1;
+}
+
+function square_webhook_touch_state(mysqli $conn, array $fields): void
+{
+    if (!$fields) {
+        return;
+    }
+
+    $columns = [];
+    $updates = [];
+    $types = 's';
+    $values = ['square_core'];
+
+    foreach ($fields as $column => $value) {
+        $columns[] = sprintf('`%s`', $column);
+        $updates[] = sprintf('`%s` = VALUES(`%s`)', $column, $column);
+        $types .= 's';
+        $values[] = (string) $value;
+    }
+
+    $placeholders = implode(', ', array_fill(0, count($columns) + 1, '?'));
+    $sql = sprintf(
+        'INSERT INTO square_sync_state (setting_key, %s) VALUES (%s) ON DUPLICATE KEY UPDATE %s',
+        implode(', ', $columns),
+        $placeholders,
+        implode(', ', $updates)
+    );
+
+    $stmt = $conn->prepare($sql);
+    if ($stmt === false) {
+        return;
+    }
+
+    $stmt->bind_param($types, ...$values);
+    $stmt->execute();
+    $stmt->close();
+}
+
+function square_webhook_handle_payment(mysqli $conn, array $payload): bool
+{
+    $payment = $payload['data']['object']['payment'] ?? null;
+    if (!is_array($payment)) {
+        return false;
+    }
+
+    $paymentId = (string) ($payment['id'] ?? '');
+    if ($paymentId === '') {
+        return false;
+    }
+
+    $status = strtoupper((string) ($payment['status'] ?? ''));
+
+    $paymentRecordId = null;
+    if ($stmt = $conn->prepare('SELECT id FROM payments WHERE payment_id = ? LIMIT 1')) {
+        $stmt->bind_param('s', $paymentId);
+        if ($stmt->execute()) {
+            $stmt->bind_result($localId);
+            if ($stmt->fetch()) {
+                $paymentRecordId = (int) $localId;
+            }
+        }
+        $stmt->close();
+    }
+
+    if ($paymentRecordId !== null && $stmt = $conn->prepare('UPDATE payments SET status = ? WHERE id = ?')) {
+        $stmt->bind_param('si', $status, $paymentRecordId);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    if ($paymentRecordId === null) {
+        return true;
+    }
+
+    $targetStatus = null;
+    if (in_array($status, ['COMPLETED', 'APPROVED'], true)) {
+        $targetStatus = 'paid';
+    } elseif (in_array($status, ['CANCELED', 'FAILED'], true)) {
+        $targetStatus = 'cancelled';
+    }
+
+    if ($targetStatus === null) {
+        return true;
+    }
+
+    $fulfillments = [];
+    if ($stmt = $conn->prepare('SELECT id, status FROM order_fulfillments WHERE payment_id = ?')) {
+        $stmt->bind_param('i', $paymentRecordId);
+        if ($stmt->execute() && ($result = $stmt->get_result())) {
+            while ($row = $result->fetch_assoc()) {
+                $fulfillments[] = [
+                    'id' => (int) $row['id'],
+                    'status' => (string) ($row['status'] ?? ''),
+                ];
+            }
+            $result->free();
+        }
+        $stmt->close();
+    }
+
+    foreach ($fulfillments as $fulfillment) {
+        $current = strtolower($fulfillment['status']);
+        $shouldUpdate = false;
+        if ($targetStatus === 'paid' && in_array($current, ['pending', 'new'], true)) {
+            $shouldUpdate = true;
+        }
+        if ($targetStatus === 'cancelled' && $current !== 'completed') {
+            $shouldUpdate = true;
+        }
+
+        if (!$shouldUpdate) {
+            continue;
+        }
+
+        if ($stmt = $conn->prepare('UPDATE order_fulfillments SET status = ? WHERE id = ?')) {
+            $stmt->bind_param('si', $targetStatus, $fulfillment['id']);
+            $stmt->execute();
+            $stmt->close();
+        }
+    }
+
+    square_log('square.webhook_payment', [
+        'payment_id' => $paymentId,
+        'status' => $status,
+        'target_status' => $targetStatus,
+    ]);
+
+    return true;
+}
+
+function square_webhook_handle_order(mysqli $conn, array $payload): bool
+{
+    $order = $payload['data']['object']['order'] ?? null;
+    if (!is_array($order)) {
+        return false;
+    }
+
+    $state = strtoupper((string) ($order['state'] ?? ''));
+    $paymentIds = [];
+    $tenders = $order['tenders'] ?? [];
+    if (is_array($tenders)) {
+        foreach ($tenders as $tender) {
+            if (is_array($tender) && isset($tender['payment_id'])) {
+                $paymentId = (string) $tender['payment_id'];
+                if ($paymentId !== '') {
+                    $paymentIds[] = $paymentId;
+                }
+            }
+        }
+    }
+
+    if (!$paymentIds) {
+        return false;
+    }
+
+    $stateMap = [
+        'OPEN' => 'paid',
+        'COMPLETED' => 'completed',
+        'CANCELED' => 'cancelled',
+        'DRAFT' => 'new',
+    ];
+    $targetStatus = $stateMap[$state] ?? null;
+    if ($targetStatus === null) {
+        return false;
+    }
+
+    foreach ($paymentIds as $remotePaymentId) {
+        $paymentRecordId = null;
+        if ($stmt = $conn->prepare('SELECT id FROM payments WHERE payment_id = ? LIMIT 1')) {
+            $stmt->bind_param('s', $remotePaymentId);
+            if ($stmt->execute()) {
+                $stmt->bind_result($localId);
+                if ($stmt->fetch()) {
+                    $paymentRecordId = (int) $localId;
+                }
+            }
+            $stmt->close();
+        }
+
+        if ($paymentRecordId === null) {
+            continue;
+        }
+
+        $fulfillments = [];
+        if ($stmt = $conn->prepare('SELECT id, status FROM order_fulfillments WHERE payment_id = ?')) {
+            $stmt->bind_param('i', $paymentRecordId);
+            if ($stmt->execute() && ($result = $stmt->get_result())) {
+                while ($row = $result->fetch_assoc()) {
+                    $fulfillments[] = [
+                        'id' => (int) $row['id'],
+                        'status' => (string) ($row['status'] ?? ''),
+                    ];
+                }
+                $result->free();
+            }
+            $stmt->close();
+        }
+
+        foreach ($fulfillments as $fulfillment) {
+            $current = strtolower($fulfillment['status']);
+            $shouldUpdate = false;
+            if ($targetStatus === 'paid' && in_array($current, ['new', 'pending'], true)) {
+                $shouldUpdate = true;
+            } elseif ($targetStatus === 'completed' && !in_array($current, ['cancelled', 'completed'], true)) {
+                $shouldUpdate = true;
+            } elseif ($targetStatus === 'cancelled' && $current !== 'completed') {
+                $shouldUpdate = true;
+            } elseif ($targetStatus === 'new' && $current === 'pending') {
+                $shouldUpdate = true;
+            }
+
+            if (!$shouldUpdate) {
+                continue;
+            }
+
+            if ($stmt = $conn->prepare('UPDATE order_fulfillments SET status = ? WHERE id = ?')) {
+                $stmt->bind_param('si', $targetStatus, $fulfillment['id']);
+                $stmt->execute();
+                $stmt->close();
+            }
+        }
+    }
+
+    square_log('square.webhook_order', [
+        'state' => $state,
+        'target_status' => $targetStatus,
+        'payments' => $paymentIds,
+    ]);
+
+    return true;
+}
+
+function square_webhook_handle_inventory(mysqli $conn, array $payload): bool
+{
+    $inventory = $payload['data']['object']['inventory_counts'] ?? null;
+    if (!is_array($inventory)) {
+        return false;
+    }
+
+    $service = new InventoryService($conn);
+    $applied = 0;
+
+    foreach ($inventory as $count) {
+        if (!is_array($count)) {
+            continue;
+        }
+
+        $squareId = isset($count['catalog_object_id']) ? (string) $count['catalog_object_id'] : '';
+        if ($squareId === '') {
+            continue;
+        }
+
+        $quantity = $count['quantity'] ?? null;
+        if ($quantity === null) {
+            continue;
+        }
+        $quantityValue = is_string($quantity) || is_numeric($quantity)
+            ? (int) floor((float) $quantity)
+            : null;
+        if ($quantityValue === null) {
+            continue;
+        }
+        if ($quantityValue < 0) {
+            $quantityValue = 0;
+        }
+
+        $sku = null;
+        if ($stmt = $conn->prepare(
+            'SELECT l.product_sku FROM square_catalog_map scm '
+            . 'JOIN listings l ON l.id = scm.local_id '
+            . 'WHERE scm.local_type = "listing" AND scm.square_object_id = ? LIMIT 1'
+        )) {
+            $stmt->bind_param('s', $squareId);
+            if ($stmt->execute() && ($result = $stmt->get_result())) {
+                if ($row = $result->fetch_assoc()) {
+                    $candidate = (string) ($row['product_sku'] ?? '');
+                    if ($candidate !== '') {
+                        $sku = $candidate;
+                    }
+                }
+                $result->free();
+            }
+            $stmt->close();
+        }
+
+        if ($sku === null) {
+            continue;
+        }
+
+        try {
+            $service->reconcileExternalStock(
+                $sku,
+                $quantityValue,
+                'square_webhook',
+                null,
+                [
+                    'square_object_id' => $squareId,
+                    'state' => $count['state'] ?? null,
+                    'source' => 'webhook',
+                ]
+            );
+            $applied++;
+        } catch (Throwable $e) {
+            square_log('square.webhook_inventory_error', [
+                'sku' => $sku,
+                'square_object_id' => $squareId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    square_log('square.webhook_inventory', [
+        'applied' => $applied,
+    ]);
+
+    return $applied > 0;
+}


### PR DESCRIPTION
## Summary
- introduce a Square SyncService to orchestrate catalog pulls, inventory reconciliation, and optional push operations while updating sync state
- add a webhook endpoint that verifies signatures, deduplicates events, and applies payment/order/inventory updates with ledger entries
- wire a Sync tab with a manual "Sync Now" action in Shop Manager and expose the webhook signature key in configuration

## Testing
- php -l config.php
- php -l config.example.php
- php -l includes/square-migrations.php
- php -l includes/repositories/InventoryService.php
- php -l includes/SyncService.php
- php -l includes/shop_manager.php
- php -l shop-manager/index.php
- php -l shop-manager/sync.php
- php -l webhooks/square.php

------
https://chatgpt.com/codex/tasks/task_e_68d349edd124832ba429298d9804bc55