### PR TITLE
Seed service taxonomy and admin tooling

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -51,6 +51,7 @@ $requests = $stmt->fetch_all(MYSQLI_ASSOC);
         <li><a class="btn" href="users.php">Manage Users</a></li>
         <li><a class="btn" href="theme.php">Vaporwave Theme Settings</a></li>
         <li><a class="btn" href="toolbox.php">Manage Toolbox</a></li>
+        <li><a class="btn" href="service-taxonomy.php">Manage Brands &amp; Models</a></li>
         <li><a class="btn" href="wallet.php">Wallet Manager</a></li>
         <li><a class="btn" href="support.php">Support Tickets</a></li>
         <li><a class="btn" href="health.php">Square Health</a></li>

--- a/admin/service-taxonomy.php
+++ b/admin/service-taxonomy.php
@@ -1,0 +1,315 @@
+<?php
+require_once __DIR__ . '/../includes/require-auth.php';
+require_once __DIR__ . '/../includes/authz.php';
+require '../includes/db.php';
+require '../includes/csrf.php';
+
+ensure_admin('../dashboard.php');
+
+$errors = [];
+$success = isset($_GET['saved']) ? 'Changes saved.' : '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validate_token($_POST['csrf_token'] ?? '')) {
+        $errors[] = 'Invalid CSRF token. Please try again.';
+    } else {
+        $action = $_POST['action'] ?? '';
+        switch ($action) {
+            case 'add_brand':
+                $name = trim($_POST['name'] ?? '');
+                if ($name === '') {
+                    $errors[] = 'Brand name is required.';
+                    break;
+                }
+
+                if ($check = $conn->prepare('SELECT id FROM service_brands WHERE name = ? LIMIT 1')) {
+                    $check->bind_param('s', $name);
+                    $check->execute();
+                    $check->store_result();
+                    if ($check->num_rows > 0) {
+                        $errors[] = 'That brand already exists.';
+                    }
+                    $check->close();
+                }
+
+                if (empty($errors) && $stmt = $conn->prepare('INSERT INTO service_brands (name) VALUES (?)')) {
+                    $stmt->bind_param('s', $name);
+                    $stmt->execute();
+                    $stmt->close();
+                    header('Location: service-taxonomy.php?saved=1');
+                    exit;
+                }
+                break;
+
+            case 'update_brand':
+                $brandId = (int)($_POST['brand_id'] ?? 0);
+                $name = trim($_POST['name'] ?? '');
+                if ($brandId <= 0) {
+                    $errors[] = 'Unknown brand selected.';
+                    break;
+                }
+                if ($name === '') {
+                    $errors[] = 'Brand name is required.';
+                    break;
+                }
+
+                if ($check = $conn->prepare('SELECT id FROM service_brands WHERE name = ? AND id <> ? LIMIT 1')) {
+                    $check->bind_param('si', $name, $brandId);
+                    $check->execute();
+                    $check->store_result();
+                    if ($check->num_rows > 0) {
+                        $errors[] = 'Another brand already uses that name.';
+                    }
+                    $check->close();
+                }
+
+                if (empty($errors) && $stmt = $conn->prepare('UPDATE service_brands SET name = ? WHERE id = ?')) {
+                    $stmt->bind_param('si', $name, $brandId);
+                    $stmt->execute();
+                    $stmt->close();
+                    header('Location: service-taxonomy.php?saved=1');
+                    exit;
+                }
+                break;
+
+            case 'add_model':
+                $brandId = (int)($_POST['brand_id'] ?? 0);
+                $name = trim($_POST['name'] ?? '');
+                if ($brandId <= 0) {
+                    $errors[] = 'Select a brand for the model.';
+                    break;
+                }
+                if ($name === '') {
+                    $errors[] = 'Model name is required.';
+                    break;
+                }
+
+                $brandExists = false;
+                if ($checkBrand = $conn->prepare('SELECT id FROM service_brands WHERE id = ? LIMIT 1')) {
+                    $checkBrand->bind_param('i', $brandId);
+                    $checkBrand->execute();
+                    $checkBrand->store_result();
+                    $brandExists = $checkBrand->num_rows > 0;
+                    $checkBrand->close();
+                }
+                if (!$brandExists) {
+                    $errors[] = 'Selected brand no longer exists.';
+                    break;
+                }
+
+                if ($check = $conn->prepare('SELECT id FROM service_models WHERE brand_id = ? AND name = ? LIMIT 1')) {
+                    $check->bind_param('is', $brandId, $name);
+                    $check->execute();
+                    $check->store_result();
+                    if ($check->num_rows > 0) {
+                        $errors[] = 'That model already exists for the brand.';
+                    }
+                    $check->close();
+                }
+
+                if (empty($errors) && $stmt = $conn->prepare('INSERT INTO service_models (brand_id, name) VALUES (?, ?)')) {
+                    $stmt->bind_param('is', $brandId, $name);
+                    $stmt->execute();
+                    $stmt->close();
+                    header('Location: service-taxonomy.php?saved=1');
+                    exit;
+                }
+                break;
+
+            case 'update_model':
+                $modelId = (int)($_POST['model_id'] ?? 0);
+                $brandId = (int)($_POST['brand_id'] ?? 0);
+                $name = trim($_POST['name'] ?? '');
+                if ($modelId <= 0) {
+                    $errors[] = 'Unknown model selected.';
+                    break;
+                }
+                if ($brandId <= 0) {
+                    $errors[] = 'Select a brand for the model.';
+                    break;
+                }
+                if ($name === '') {
+                    $errors[] = 'Model name is required.';
+                    break;
+                }
+
+                $brandExists = false;
+                if ($checkBrand = $conn->prepare('SELECT id FROM service_brands WHERE id = ? LIMIT 1')) {
+                    $checkBrand->bind_param('i', $brandId);
+                    $checkBrand->execute();
+                    $checkBrand->store_result();
+                    $brandExists = $checkBrand->num_rows > 0;
+                    $checkBrand->close();
+                }
+                if (!$brandExists) {
+                    $errors[] = 'Selected brand no longer exists.';
+                    break;
+                }
+
+                if ($check = $conn->prepare('SELECT id FROM service_models WHERE brand_id = ? AND name = ? AND id <> ? LIMIT 1')) {
+                    $check->bind_param('isi', $brandId, $name, $modelId);
+                    $check->execute();
+                    $check->store_result();
+                    if ($check->num_rows > 0) {
+                        $errors[] = 'Another model with that name already exists for the brand.';
+                    }
+                    $check->close();
+                }
+
+                if (empty($errors) && $stmt = $conn->prepare('UPDATE service_models SET brand_id = ?, name = ? WHERE id = ?')) {
+                    $stmt->bind_param('isi', $brandId, $name, $modelId);
+                    $stmt->execute();
+                    $stmt->close();
+                    header('Location: service-taxonomy.php?saved=1');
+                    exit;
+                }
+                break;
+
+            default:
+                $errors[] = 'Unknown action requested.';
+        }
+    }
+}
+
+$brands = [];
+if ($result = $conn->query('SELECT id, name FROM service_brands ORDER BY name')) {
+    while ($row = $result->fetch_assoc()) {
+        $id = (int)$row['id'];
+        $brands[$id] = [
+            'id' => $id,
+            'name' => $row['name'],
+            'models' => [],
+        ];
+    }
+}
+
+if (!empty($brands)) {
+    $brandIds = implode(',', array_keys($brands));
+    if ($brandIds !== '' && $result = $conn->query('SELECT id, brand_id, name FROM service_models WHERE brand_id IN (' . $brandIds . ') ORDER BY name')) {
+        while ($row = $result->fetch_assoc()) {
+            $brandId = (int)$row['brand_id'];
+            if (isset($brands[$brandId])) {
+                $brands[$brandId]['models'][] = [
+                    'id' => (int)$row['id'],
+                    'brand_id' => $brandId,
+                    'name' => $row['name'],
+                ];
+            }
+        }
+    }
+}
+
+$brandOptions = array_values($brands);
+?>
+<?php require '../includes/layout.php'; ?>
+  <title>Service Taxonomy</title>
+  <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+  <?php include '../includes/header.php'; ?>
+  <h2>Service Taxonomy</h2>
+  <p><a class="btn" href="index.php">Back to Admin Panel</a></p>
+
+  <?php if (!empty($success)): ?>
+    <p style="color:green;"><?= htmlspecialchars($success) ?></p>
+  <?php endif; ?>
+  <?php if (!empty($errors)): ?>
+    <div style="color:red;">
+      <ul>
+        <?php foreach ($errors as $error): ?>
+          <li><?= htmlspecialchars($error) ?></li>
+        <?php endforeach; ?>
+      </ul>
+    </div>
+  <?php endif; ?>
+
+  <section>
+    <h3>Add Brand</h3>
+    <form method="post">
+      <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+      <input type="hidden" name="action" value="add_brand">
+      <label>Brand Name
+        <input type="text" name="name" required>
+      </label>
+      <button type="submit">Add Brand</button>
+    </form>
+  </section>
+
+  <section>
+    <h3>Add Model</h3>
+    <form method="post">
+      <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+      <input type="hidden" name="action" value="add_model">
+      <label>Brand
+        <select name="brand_id" required>
+          <option value="">Select a brand</option>
+          <?php foreach ($brandOptions as $brand): ?>
+            <option value="<?= $brand['id']; ?>"><?= htmlspecialchars($brand['name']); ?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label>Model Name
+        <input type="text" name="name" required>
+      </label>
+      <button type="submit">Add Model</button>
+    </form>
+  </section>
+
+  <section>
+    <h3>Existing Brands &amp; Models</h3>
+    <?php if (empty($brandOptions)): ?>
+      <p>No brands found. Add one above to get started.</p>
+    <?php else: ?>
+      <?php foreach ($brandOptions as $brand): ?>
+        <div class="card" style="margin-bottom: 1.5rem; padding: 1rem;">
+          <form method="post" style="margin-bottom: 1rem;">
+            <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+            <input type="hidden" name="action" value="update_brand">
+            <input type="hidden" name="brand_id" value="<?= $brand['id']; ?>">
+            <label>Brand Name
+              <input type="text" name="name" value="<?= htmlspecialchars($brand['name']); ?>" required>
+            </label>
+            <button type="submit">Save Brand</button>
+          </form>
+
+          <?php if (empty($brand['models'])): ?>
+            <p>No models for this brand yet.</p>
+          <?php else: ?>
+            <table>
+              <thead>
+                <tr>
+                  <th style="text-align:left;">Model</th>
+                  <th style="text-align:left;">Brand</th>
+                </tr>
+              </thead>
+              <tbody>
+                <?php foreach ($brand['models'] as $model): ?>
+                  <tr>
+                    <td>
+                      <form method="post" style="display:flex; gap:0.5rem; align-items:center;">
+                        <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
+                        <input type="hidden" name="action" value="update_model">
+                        <input type="hidden" name="model_id" value="<?= $model['id']; ?>">
+                        <input type="text" name="name" value="<?= htmlspecialchars($model['name']); ?>" required>
+                        <select name="brand_id" required>
+                          <?php foreach ($brandOptions as $option): ?>
+                            <option value="<?= $option['id']; ?>" <?= $option['id'] === $model['brand_id'] ? 'selected' : ''; ?>><?= htmlspecialchars($option['name']); ?></option>
+                          <?php endforeach; ?>
+                        </select>
+                        <button type="submit">Save</button>
+                      </form>
+                    </td>
+                    <td><?= htmlspecialchars($brand['name']); ?></td>
+                  </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          <?php endif; ?>
+        </div>
+      <?php endforeach; ?>
+    <?php endif; ?>
+  </section>
+
+  <?php include '../includes/footer.php'; ?>
+</body>
+</html>

--- a/api/listings.php
+++ b/api/listings.php
@@ -24,7 +24,7 @@ if (!in_array($context, ['buy', 'trade'], true)) {
 
 try {
     if ($context === 'buy') {
-        $filters = sanitize_buy_filters($_GET);
+        $filters = sanitize_buy_filters($_GET, $conn);
         $result = run_buy_listing_query($conn, $filters);
         $active = $result['filters'];
         $listings = $result['items'];
@@ -37,6 +37,8 @@ try {
         $categoryOptions = listing_filter_categories('buy');
         $subcategoryOptions = listing_filter_subcategories('buy', $active['category']);
         $conditionOptions = listing_filter_conditions('buy', $active['category']);
+        $brandOptions = listing_brand_options($conn);
+        $modelIndex = listing_model_index($conn);
         $sortOptions = buy_sort_options();
         $limitOptions = buy_limit_options();
         $availableTags = load_available_tags($conn, $tagFilters);
@@ -46,6 +48,8 @@ try {
             'category' => $active['category'] !== '' ? $active['category'] : null,
             'subcategory' => $active['subcategory'] !== '' ? $active['subcategory'] : null,
             'condition' => $active['condition'] !== '' ? $active['condition'] : null,
+            'brand_id' => $active['brand_id'] > 0 ? $active['brand_id'] : null,
+            'model_id' => $active['model_id'] > 0 ? $active['model_id'] : null,
             'sort' => $active['sort'] !== '' ? $active['sort'] : null,
             'limit' => $limit,
             'tags' => !empty($tagFilters) ? $tagFilters : null,
@@ -117,6 +121,36 @@ try {
             ];
         }
 
+        $brandData = [];
+        $brandData[] = [
+            'value' => '',
+            'label' => 'Any brand',
+            'selected' => $active['brand_id'] <= 0,
+        ];
+        foreach ($brandOptions as $id => $name) {
+            $brandData[] = [
+                'value' => (string)$id,
+                'label' => $name,
+                'selected' => (int)$active['brand_id'] === (int)$id,
+            ];
+        }
+
+        $modelData = [];
+        $modelData[] = [
+            'value' => '',
+            'label' => 'Any model',
+            'selected' => $active['model_id'] <= 0,
+        ];
+        foreach ($modelIndex as $model) {
+            $brandLabel = $brandOptions[$model['brand_id']] ?? ('Brand ' . $model['brand_id']);
+            $modelLabel = $brandLabel . ' – ' . $model['name'];
+            $modelData[] = [
+                'value' => (string)$model['id'],
+                'label' => $modelLabel,
+                'selected' => (int)$active['model_id'] === (int)$model['id'],
+            ];
+        }
+
         $tagData = [];
         foreach ($availableTags as $tag) {
             $tagData[] = [
@@ -156,6 +190,8 @@ try {
                 'category' => $categoryData,
                 'subcategory' => $subcategoryData,
                 'condition' => $conditionData,
+                'brand' => $brandData,
+                'model' => $modelData,
                 'tags' => $tagData,
                 'sort' => $sortData,
                 'limit' => $limitData,
@@ -165,7 +201,7 @@ try {
     }
 
     // Trade context
-    $filters = sanitize_trade_filters($_GET);
+    $filters = sanitize_trade_filters($_GET, $conn);
     $result = run_trade_listing_query($conn, $filters);
     $active = $result['filters'];
     $listings = $result['items'];
@@ -178,6 +214,8 @@ try {
     $subcategoryOptions = listing_filter_subcategories('trade', $active['category']);
     $conditionOptions = listing_filter_conditions('trade', $active['category']);
     $formatOptions = listing_filter_format_options('trade');
+    $brandOptions = listing_brand_options($conn);
+    $modelIndex = listing_model_index($conn);
     $sortOptions = trade_sort_options();
     $limitOptions = trade_limit_options();
 
@@ -187,6 +225,8 @@ try {
         'subcategory' => $active['subcategory'] !== '' ? $active['subcategory'] : null,
         'condition' => $active['condition'] !== '' ? $active['condition'] : null,
         'trade_type' => $active['trade_type'] !== '' ? $active['trade_type'] : null,
+        'brand_id' => $active['brand_id'] > 0 ? $active['brand_id'] : null,
+        'model_id' => $active['model_id'] > 0 ? $active['model_id'] : null,
         'sort' => $active['sort'] !== '' ? $active['sort'] : null,
         'limit' => $limit,
     ];
@@ -253,6 +293,36 @@ try {
         ];
     }
 
+    $brandData = [];
+    $brandData[] = [
+        'value' => '',
+        'label' => 'Any brand',
+        'selected' => $active['brand_id'] <= 0,
+    ];
+    foreach ($brandOptions as $id => $name) {
+        $brandData[] = [
+            'value' => (string)$id,
+            'label' => $name,
+            'selected' => (int)$active['brand_id'] === (int)$id,
+        ];
+    }
+
+    $modelData = [];
+    $modelData[] = [
+        'value' => '',
+        'label' => 'Any model',
+        'selected' => $active['model_id'] <= 0,
+    ];
+    foreach ($modelIndex as $model) {
+        $brandLabel = $brandOptions[$model['brand_id']] ?? ('Brand ' . $model['brand_id']);
+        $modelLabel = $brandLabel . ' – ' . $model['name'];
+        $modelData[] = [
+            'value' => (string)$model['id'],
+            'label' => $modelLabel,
+            'selected' => (int)$active['model_id'] === (int)$model['id'],
+        ];
+    }
+
     $formatData = [];
     foreach ($formatOptions as $value => $label) {
         $count = $optionCounts([
@@ -298,6 +368,8 @@ try {
             'category' => $categoryData,
             'subcategory' => $subcategoryData,
             'condition' => $conditionData,
+            'brand' => $brandData,
+            'model' => $modelData,
             'trade_type' => $formatData,
             'sort' => $sortData,
             'limit' => $limitData,

--- a/assets/js/filters.js
+++ b/assets/js/filters.js
@@ -108,6 +108,12 @@ const updateFormControls = (form, filters) => {
   updateSelectOptions(form.querySelector('[name="category"]'), filters.category);
   updateSelectOptions(form.querySelector('[name="subcategory"]'), filters.subcategory);
   updateSelectOptions(form.querySelector('[name="condition"]'), filters.condition);
+  if (filters.brand) {
+    updateSelectOptions(form.querySelector('[name="brand_id"]'), filters.brand);
+  }
+  if (filters.model) {
+    updateSelectOptions(form.querySelector('[name="model_id"]'), filters.model);
+  }
   if (filters.trade_type) {
     updateSelectOptions(form.querySelector('[name="trade_type"]'), filters.trade_type);
   }

--- a/cart.php
+++ b/cart.php
@@ -216,6 +216,20 @@ if (!empty($_SESSION['cart'])) {
 $tax = 0.0; // placeholder
 $shipping = 0.0; // placeholder
 $grand_total = $total + $tax + $shipping;
+
+$targetListingId = 0;
+$checkoutListingIds = [];
+if (!empty($cart_items)) {
+    $firstItem = $cart_items[0];
+    if (isset($firstItem['id'])) {
+        $targetListingId = (int) $firstItem['id'];
+    }
+    foreach ($cart_items as $item) {
+        if (isset($item['id'])) {
+            $checkoutListingIds[] = (int) $item['id'];
+        }
+    }
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -278,6 +292,14 @@ $grand_total = $total + $tax + $shipping;
     <button type="submit">Update Cart</button>
 </form>
 <form action="checkout.php" method="get">
+    <?php if ($targetListingId > 0): ?>
+        <input type="hidden" name="listing_id" value="<?= $targetListingId; ?>">
+    <?php endif; ?>
+    <?php if (!empty($checkoutListingIds)): ?>
+        <?php foreach ($checkoutListingIds as $id): ?>
+            <input type="hidden" name="listing_id[]" value="<?= $id; ?>">
+        <?php endforeach; ?>
+    <?php endif; ?>
     <button type="submit">Proceed to Checkout</button>
 </form>
 <?php endif; ?>

--- a/includes/partials/buy-results.php
+++ b/includes/partials/buy-results.php
@@ -39,6 +39,18 @@
             <img class="thumb-square" src="uploads/<?= htmlspecialchars($l['image']); ?>" alt="">
           <?php endif; ?>
           <h3><?= htmlspecialchars($l['title']); ?></h3>
+          <?php if (!empty($l['brand_name']) || !empty($l['model_name'])): ?>
+            <p class="device-meta">
+              <?php if (!empty($l['brand_name'])): ?>
+                <?= htmlspecialchars($l['brand_name']); ?>
+                <?php if (!empty($l['model_name'])): ?>
+                  &middot; <?= htmlspecialchars($l['model_name']); ?>
+                <?php endif; ?>
+              <?php else: ?>
+                <?= htmlspecialchars($l['model_name']); ?>
+              <?php endif; ?>
+            </p>
+          <?php endif; ?>
         </a>
         <?php
           $badges = [];

--- a/includes/partials/trade-results.php
+++ b/includes/partials/trade-results.php
@@ -46,7 +46,21 @@
       <tbody>
         <?php foreach ($listings as $l): ?>
           <tr>
-            <td><?= htmlspecialchars($l['have_item']); ?></td>
+            <td>
+              <?= htmlspecialchars($l['have_item']); ?>
+              <?php if (!empty($l['brand_name']) || !empty($l['model_name'])): ?>
+                <br><small>
+                  <?php if (!empty($l['brand_name'])): ?>
+                    <?= htmlspecialchars($l['brand_name']); ?>
+                    <?php if (!empty($l['model_name'])): ?>
+                      &middot; <?= htmlspecialchars($l['model_name']); ?>
+                    <?php endif; ?>
+                  <?php else: ?>
+                    <?= htmlspecialchars($l['model_name']); ?>
+                  <?php endif; ?>
+                </small>
+              <?php endif; ?>
+            </td>
             <td><?= htmlspecialchars($l['want_item']); ?></td>
             <td><?= htmlspecialchars($l['trade_type']); ?></td>
             <td><?= htmlspecialchars($l['description']); ?></td>

--- a/listing.php
+++ b/listing.php
@@ -12,7 +12,16 @@ if (!$listing_id) {
     exit;
 }
 
-$stmt = $conn->prepare('SELECT l.id, l.product_sku, l.title, l.description, l.price, l.sale_price, l.category, l.tags, l.image, l.pickup_only, l.is_official_listing, l.quantity, l.reserved_qty, l.owner_id, p.is_skuze_official, p.is_skuze_product FROM listings l LEFT JOIN products p ON l.product_sku = p.sku WHERE l.id = ? LIMIT 1');
+$stmt = $conn->prepare(
+    'SELECT l.id, l.product_sku, l.title, l.description, l.price, l.sale_price, l.category, l.tags, l.image, '
+    . 'l.brand_id, l.model_id, sb.name AS brand_name, sm.name AS model_name, l.pickup_only, l.is_official_listing, '
+    . 'l.quantity, l.reserved_qty, l.owner_id, p.is_skuze_official, p.is_skuze_product '
+    . 'FROM listings l '
+    . 'LEFT JOIN service_brands sb ON sb.id = l.brand_id '
+    . 'LEFT JOIN service_models sm ON sm.id = l.model_id '
+    . 'LEFT JOIN products p ON l.product_sku = p.sku '
+    . 'WHERE l.id = ? LIMIT 1'
+);
 $stmt->bind_param('i', $listing_id);
 $stmt->execute();
 $result = $stmt->get_result();
@@ -101,6 +110,18 @@ $offerCsrfToken = generate_token();
           }
         ?>
       </h2>
+      <?php if (!empty($listing['brand_name']) || !empty($listing['model_name'])): ?>
+        <p class="device-meta">
+          <?php if (!empty($listing['brand_name'])): ?>
+            <?= htmlspecialchars($listing['brand_name']); ?>
+            <?php if (!empty($listing['model_name'])): ?>
+              &middot; <?= htmlspecialchars($listing['model_name']); ?>
+            <?php endif; ?>
+          <?php else: ?>
+            <?= htmlspecialchars($listing['model_name']); ?>
+          <?php endif; ?>
+        </p>
+      <?php endif; ?>
       <p class="description">
         <?= nl2br(htmlspecialchars($listing['description'])); ?>
       </p>

--- a/migrations/041_add_brand_model_to_listings.sql
+++ b/migrations/041_add_brand_model_to_listings.sql
@@ -1,0 +1,17 @@
+ALTER TABLE listings
+    ADD COLUMN IF NOT EXISTS brand_id INT NULL AFTER product_sku,
+    ADD COLUMN IF NOT EXISTS model_id INT NULL AFTER brand_id,
+    ADD CONSTRAINT fk_listings_brand FOREIGN KEY (brand_id) REFERENCES service_brands(id),
+    ADD CONSTRAINT fk_listings_model FOREIGN KEY (model_id) REFERENCES service_models(id);
+
+CREATE INDEX IF NOT EXISTS idx_listings_brand_id ON listings(brand_id);
+CREATE INDEX IF NOT EXISTS idx_listings_model_id ON listings(model_id);
+
+ALTER TABLE trade_listings
+    ADD COLUMN IF NOT EXISTS brand_id INT NULL AFTER want_item,
+    ADD COLUMN IF NOT EXISTS model_id INT NULL AFTER brand_id,
+    ADD CONSTRAINT fk_trade_listings_brand FOREIGN KEY (brand_id) REFERENCES service_brands(id),
+    ADD CONSTRAINT fk_trade_listings_model FOREIGN KEY (model_id) REFERENCES service_models(id);
+
+CREATE INDEX IF NOT EXISTS idx_trade_listings_brand_id ON trade_listings(brand_id);
+CREATE INDEX IF NOT EXISTS idx_trade_listings_model_id ON trade_listings(model_id);

--- a/migrations/042_seed_service_taxonomy.sql
+++ b/migrations/042_seed_service_taxonomy.sql
@@ -1,0 +1,241 @@
+-- Seed canonical service brands and models for core hardware categories.
+
+-- Phones
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Apple') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Apple');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'iPhone 15 Pro'
+FROM service_brands b
+WHERE b.name = 'Apple'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'iPhone 15 Pro');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'iPhone 14'
+FROM service_brands b
+WHERE b.name = 'Apple'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'iPhone 14');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Samsung') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Samsung');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Galaxy S23 Ultra'
+FROM service_brands b
+WHERE b.name = 'Samsung'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Galaxy S23 Ultra');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Galaxy Z Flip5'
+FROM service_brands b
+WHERE b.name = 'Samsung'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Galaxy Z Flip5');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Google') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Google');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Pixel 8 Pro'
+FROM service_brands b
+WHERE b.name = 'Google'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Pixel 8 Pro');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Pixel 7a'
+FROM service_brands b
+WHERE b.name = 'Google'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Pixel 7a');
+
+-- Consoles & handhelds
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Sony') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Sony');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'PlayStation 5'
+FROM service_brands b
+WHERE b.name = 'Sony'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'PlayStation 5');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'PlayStation 4 Pro'
+FROM service_brands b
+WHERE b.name = 'Sony'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'PlayStation 4 Pro');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Microsoft') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Microsoft');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Xbox Series X'
+FROM service_brands b
+WHERE b.name = 'Microsoft'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Xbox Series X');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Xbox Series S'
+FROM service_brands b
+WHERE b.name = 'Microsoft'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Xbox Series S');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Nintendo') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Nintendo');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Switch OLED'
+FROM service_brands b
+WHERE b.name = 'Nintendo'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Switch OLED');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Switch Lite'
+FROM service_brands b
+WHERE b.name = 'Nintendo'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Switch Lite');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Valve') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Valve');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Steam Deck OLED'
+FROM service_brands b
+WHERE b.name = 'Valve'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Steam Deck OLED');
+
+-- Laptops & PCs
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Dell') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Dell');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'XPS 13 Plus'
+FROM service_brands b
+WHERE b.name = 'Dell'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'XPS 13 Plus');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Alienware m16'
+FROM service_brands b
+WHERE b.name = 'Dell'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Alienware m16');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Lenovo') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Lenovo');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'ThinkPad X1 Carbon'
+FROM service_brands b
+WHERE b.name = 'Lenovo'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'ThinkPad X1 Carbon');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Legion Pro 7i'
+FROM service_brands b
+WHERE b.name = 'Lenovo'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Legion Pro 7i');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'HP') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'HP');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Spectre x360 13.5'
+FROM service_brands b
+WHERE b.name = 'HP'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Spectre x360 13.5');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Omen 16'
+FROM service_brands b
+WHERE b.name = 'HP'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Omen 16');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'ASUS') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'ASUS');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'ROG Zephyrus G14'
+FROM service_brands b
+WHERE b.name = 'ASUS'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'ROG Zephyrus G14');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Zenbook 14 OLED'
+FROM service_brands b
+WHERE b.name = 'ASUS'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Zenbook 14 OLED');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'MSI') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'MSI');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Raider GE78 HX'
+FROM service_brands b
+WHERE b.name = 'MSI'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Raider GE78 HX');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Stealth 14 Studio'
+FROM service_brands b
+WHERE b.name = 'MSI'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Stealth 14 Studio');
+
+-- GPUs
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'NVIDIA') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'NVIDIA');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'GeForce RTX 4090'
+FROM service_brands b
+WHERE b.name = 'NVIDIA'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'GeForce RTX 4090');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'GeForce RTX 4080 Super'
+FROM service_brands b
+WHERE b.name = 'NVIDIA'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'GeForce RTX 4080 Super');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'AMD') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'AMD');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Radeon RX 7900 XTX'
+FROM service_brands b
+WHERE b.name = 'AMD'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Radeon RX 7900 XTX');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Radeon RX 7700 XT'
+FROM service_brands b
+WHERE b.name = 'AMD'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Radeon RX 7700 XT');
+
+-- CPUs
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Ryzen 9 7950X'
+FROM service_brands b
+WHERE b.name = 'AMD'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Ryzen 9 7950X');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Ryzen 7 7800X3D'
+FROM service_brands b
+WHERE b.name = 'AMD'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Ryzen 7 7800X3D');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Intel') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Intel');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Core i9-13900K'
+FROM service_brands b
+WHERE b.name = 'Intel'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Core i9-13900K');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Core i7-13700K'
+FROM service_brands b
+WHERE b.name = 'Intel'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Core i7-13700K');
+
+-- Components & accessories
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Logitech') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Logitech');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'G Pro X Superlight 2'
+FROM service_brands b
+WHERE b.name = 'Logitech'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'G Pro X Superlight 2');
+
+INSERT INTO service_brands (name)
+SELECT * FROM (SELECT 'Elgato') AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM service_brands WHERE name = 'Elgato');
+INSERT INTO service_models (brand_id, name)
+SELECT b.id, 'Stream Deck MK.2'
+FROM service_brands b
+WHERE b.name = 'Elgato'
+  AND NOT EXISTS (SELECT 1 FROM service_models sm WHERE sm.brand_id = b.id AND sm.name = 'Stream Deck MK.2');

--- a/sell-step.php
+++ b/sell-step.php
@@ -1,12 +1,19 @@
 <?php
 require_once __DIR__ . '/includes/require-auth.php';
+require 'includes/db.php';
 require 'includes/csrf.php';
+require 'includes/listing-query.php';
 
 $category = $_GET['category'] ?? '';
 if (!$category) {
   header('Location: sell.php');
   exit;
 }
+
+$brandOptions = listing_brand_options($conn);
+$modelIndex = listing_model_index($conn);
+$selectedBrandId = isset($_POST['brand_id']) ? (int)$_POST['brand_id'] : 0;
+$selectedModelId = isset($_POST['model_id']) ? (int)$_POST['model_id'] : 0;
 
 function label($text, $name, $type = 'text', $required = true) {
   echo "<label>$text</label>";
@@ -26,6 +33,26 @@ function label($text, $name, $type = 'text', $required = true) {
     <input type="hidden" name="csrf_token" value="<?= generate_token(); ?>">
     <input type="hidden" name="type" value="sell">
     <input type="hidden" name="category" value="<?= htmlspecialchars($category) ?>">
+
+    <label>Brand</label>
+    <select name="brand_id">
+      <option value="">Select brand</option>
+      <?php foreach ($brandOptions as $id => $name): ?>
+        <option value="<?= $id; ?>" <?= $selectedBrandId === (int)$id ? 'selected' : ''; ?>><?= htmlspecialchars($name); ?></option>
+      <?php endforeach; ?>
+    </select>
+
+    <label>Model</label>
+    <select name="model_id" <?= empty($modelIndex) ? 'disabled' : ''; ?>>
+      <option value="">Select model</option>
+      <?php foreach ($modelIndex as $model): ?>
+        <?php
+          $brandLabel = $brandOptions[$model['brand_id']] ?? ('Brand ' . $model['brand_id']);
+          $modelLabel = $brandLabel . ' – ' . $model['name'];
+        ?>
+        <option value="<?= $model['id']; ?>" data-brand-id="<?= $model['brand_id']; ?>" <?= $selectedModelId === (int)$model['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($modelLabel); ?></option>
+      <?php endforeach; ?>
+    </select>
 
     <?php if ($category === 'phone' || $category === 'console' || $category === 'pc'): ?>
       <?php label('Make', 'make'); ?>

--- a/shop-manager/index.php
+++ b/shop-manager/index.php
@@ -18,6 +18,7 @@ require_once __DIR__ . '/../includes/repositories/ChangeRequestsService.php';
 require_once __DIR__ . '/../includes/repositories/ListingsRepo.php';
 require_once __DIR__ . '/../includes/repositories/SquareCatalogSync.php';
 require_once __DIR__ . '/../includes/SyncService.php';
+require_once __DIR__ . '/../includes/listing-query.php';
 
 $config = require __DIR__ . '/../config.php';
 
@@ -101,6 +102,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $title = trim((string) ($_POST['title'] ?? ''));
                 $priceInput = trim((string) ($_POST['price'] ?? ''));
                 $quantityInput = trim((string) ($_POST['quantity'] ?? ''));
+                $brandInput = trim((string) ($_POST['brand_id'] ?? ''));
+                $modelInput = trim((string) ($_POST['model_id'] ?? ''));
 
                 if ($listingId <= 0) {
                     shop_manager_flash($redirectTab, 'error', 'Invalid listing selected.');
@@ -121,6 +124,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'title' => $title,
                     'price' => $priceInput,
                     'quantity' => $quantityInput,
+                    'brand_id' => $brandInput,
+                    'model_id' => $modelInput,
                 ];
 
                 try {
@@ -242,6 +247,8 @@ $listingsFilters = [
 ];
 $listingsData = $listingsRepository->paginateForOwner($viewerId, $listingsFilters, $squareSyncEnabled);
 $listingsStatuses = $listingsRepository->allowedStatuses();
+$serviceBrandOptions = listing_brand_options($db);
+$serviceModelIndex = listing_model_index($db);
 
 $productsList = store_fetch_products($db, $viewerId, $managerScope);
 $storeInventory = store_fetch_inventory($db, $viewerId, $managerScope);

--- a/shop-manager/listings.php
+++ b/shop-manager/listings.php
@@ -101,6 +101,10 @@ $currentScope = $managerScope ?? STORE_SCOPE_MINE;
               ? number_format($originalCeilingNumeric, 2, '.', '')
               : '';
             $currentPriceDisplay = number_format((float) $item['price'], 2);
+            $currentBrandId = isset($item['brand_id']) ? (int) $item['brand_id'] : 0;
+            $currentModelId = isset($item['model_id']) ? (int) $item['model_id'] : 0;
+            $currentBrandName = $item['brand_name'] ?? ($currentBrandId > 0 ? ($serviceBrandOptions[$currentBrandId] ?? null) : null);
+            $currentModelName = $item['model_name'] ?? ($currentModelId > 0 && isset($serviceModelIndex[$currentModelId]) ? $serviceModelIndex[$currentModelId]['name'] : null);
           ?>
           <tr data-listing-id="<?= $listingId; ?>">
             <th scope="row">
@@ -112,6 +116,18 @@ $currentScope = $managerScope ?? STORE_SCOPE_MINE;
                 <?= htmlspecialchars($item['category'] ?: 'Uncategorised', ENT_QUOTES, 'UTF-8'); ?>
                 <?php if ($item['pickup_only']): ?> · Pickup only<?php endif; ?>
               </small><br>
+              <?php if ($currentBrandName || $currentModelName): ?>
+                <small>
+                  <?php if ($currentBrandName): ?>
+                    <?= htmlspecialchars($currentBrandName, ENT_QUOTES, 'UTF-8'); ?>
+                    <?php if ($currentModelName): ?>
+                      &middot; <?= htmlspecialchars($currentModelName, ENT_QUOTES, 'UTF-8'); ?>
+                    <?php endif; ?>
+                  <?php else: ?>
+                    <?= htmlspecialchars($currentModelName, ENT_QUOTES, 'UTF-8'); ?>
+                  <?php endif; ?>
+                </small><br>
+              <?php endif; ?>
               <small>Price: $<?= htmlspecialchars($currentPriceDisplay, ENT_QUOTES, 'UTF-8'); ?></small><br>
               <?php if (!empty($item['sale_price'])): ?>
                 <small>Sale price: $<?= htmlspecialchars(number_format((float) $item['sale_price'], 2), ENT_QUOTES, 'UTF-8'); ?></small><br>
@@ -191,6 +207,13 @@ $currentScope = $managerScope ?? STORE_SCOPE_MINE;
                 <div class="manager-details-grid">
                   <label class="sr-only" for="listing-title-<?= $listingId; ?>">Title</label>
                   <input id="listing-title-<?= $listingId; ?>" type="text" name="title" value="<?= htmlspecialchars($item['title'], ENT_QUOTES, 'UTF-8'); ?>" placeholder="Title">
+                  <label class="sr-only" for="listing-brand-<?= $listingId; ?>">Brand</label>
+                  <select id="listing-brand-<?= $listingId; ?>" name="brand_id">
+                    <option value="">Select brand</option>
+                    <?php foreach ($serviceBrandOptions as $brandId => $brandName): ?>
+                      <option value="<?= $brandId; ?>" <?= $currentBrandId === (int)$brandId ? 'selected' : ''; ?>><?= htmlspecialchars($brandName, ENT_QUOTES, 'UTF-8'); ?></option>
+                    <?php endforeach; ?>
+                  </select>
                   <label class="sr-only" for="listing-price-<?= $listingId; ?>">Price</label>
                   <input
                     id="listing-price-<?= $listingId; ?>"
@@ -208,6 +231,17 @@ $currentScope = $managerScope ?? STORE_SCOPE_MINE;
                     <small class="field-hint">You may lower the price, but it cannot exceed $<?= htmlspecialchars($originalCeilingDisplay, ENT_QUOTES, 'UTF-8'); ?>.</small>
                     <small class="field-hint field-hint--error" data-price-ceiling-error hidden>Price cannot exceed $<?= htmlspecialchars($originalCeilingDisplay, ENT_QUOTES, 'UTF-8'); ?>.</small>
                   <?php endif; ?>
+                  <label class="sr-only" for="listing-model-<?= $listingId; ?>">Model</label>
+                  <select id="listing-model-<?= $listingId; ?>" name="model_id" <?= empty($serviceModelIndex) ? 'disabled' : ''; ?>>
+                    <option value="">Select model</option>
+                    <?php foreach ($serviceModelIndex as $model): ?>
+                      <?php
+                        $brandLabel = $serviceBrandOptions[$model['brand_id']] ?? ('Brand ' . $model['brand_id']);
+                        $modelLabel = $brandLabel . ' – ' . $model['name'];
+                      ?>
+                      <option value="<?= $model['id']; ?>" data-brand-id="<?= $model['brand_id']; ?>" <?= $currentModelId === (int)$model['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($modelLabel, ENT_QUOTES, 'UTF-8'); ?></option>
+                    <?php endforeach; ?>
+                  </select>
                   <label class="sr-only" for="listing-quantity-<?= $listingId; ?>">Quantity</label>
                   <input id="listing-quantity-<?= $listingId; ?>" type="number" name="quantity" min="0" value="<?= $item['quantity'] !== null ? (int) $item['quantity'] : ''; ?>" placeholder="Quantity">
                 </div>

--- a/trade-step.php
+++ b/trade-step.php
@@ -27,19 +27,27 @@ function label($text, $name, $type = 'text', $required = true) {
     <input type="hidden" name="type" value="trade">
     <input type="hidden" name="category" value="<?= htmlspecialchars($category) ?>">
 
-    <?php if ($category === 'phone' || $category === 'console' || $category === 'pc'): ?>
-      <?php label("Current Device Make", 'make'); ?>
-      <?php label("Current Device Model", 'model'); ?>
-      <?php label('IMEI / Serial Number', 'serial', 'text', false); ?>
-      <?php label('Desired Device', 'device_type'); ?>
-      <?php label('Condition / Details', 'issue'); ?>
-    <?php endif; ?>
+    <?php
+      $labels = [
+        'make' => 'Current Device Make',
+        'model' => 'Current Device Model',
+        'device_type' => 'Desired Device',
+        'issue' => 'Condition / Details',
+        'serial' => 'IMEI / Serial Number',
+      ];
 
-    <?php if ($category === 'other'): ?>
-      <?php label('Device You Have', 'device_type'); ?>
-      <?php label('Desired Device', 'model'); ?>
-      <?php label('Condition / Details', 'issue'); ?>
-    <?php endif; ?>
+      if ($category === 'other') {
+        $labels['make'] = 'Device You Have';
+        $labels['model'] = 'Desired Device';
+        $labels['device_type'] = 'Preferred Replacement Details';
+      }
+    ?>
+
+    <?php label($labels['make'], 'make'); ?>
+    <?php label($labels['model'], 'model'); ?>
+    <?php label($labels['serial'], 'serial', 'text', false); ?>
+    <?php label($labels['device_type'], 'device_type'); ?>
+    <?php label($labels['issue'], 'issue'); ?>
 
     <div class="drop-area" id="drop-area">
       <p>Drag &amp; drop a photo or use the button</p>

--- a/trade.php
+++ b/trade.php
@@ -43,7 +43,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 // Fetch listing details when filtering
 if ($listing_filter) {
-    if ($stmt = $conn->prepare('SELECT have_item, want_item, trade_type, description, image FROM trade_listings WHERE id = ? AND owner_id = ?')) {
+    if ($stmt = $conn->prepare('SELECT tl.have_item, tl.want_item, tl.trade_type, tl.description, tl.image, sb.name AS brand_name, sm.name AS model_name FROM trade_listings tl LEFT JOIN service_brands sb ON sb.id = tl.brand_id LEFT JOIN service_models sm ON sm.id = tl.model_id WHERE tl.id = ? AND tl.owner_id = ?')) {
         $stmt->bind_param('ii', $listing_filter, $user_id);
         $stmt->execute();
         $listing_info = $stmt->get_result()->fetch_assoc();
@@ -93,6 +93,9 @@ if ($listing_filter) {
         <p>Have: <strong><?= htmlspecialchars($listing_info['have_item']) ?></strong></p>
         <p>Want: <strong><?= htmlspecialchars($listing_info['want_item']) ?></strong></p>
         <p>Type: <strong><?= htmlspecialchars($listing_info['trade_type']) ?></strong></p>
+        <?php if (!empty($listing_info['brand_name']) || !empty($listing_info['model_name'])): ?>
+          <p>Device: <strong><?= htmlspecialchars($listing_info['brand_name'] ?? '—') ?><?php if (!empty($listing_info['model_name'])): ?> &middot; <?= htmlspecialchars($listing_info['model_name']) ?><?php endif; ?></strong></p>
+        <?php endif; ?>
         <p><?= nl2br(htmlspecialchars($listing_info['description'])) ?></p>
       <?php if (!empty($listing_info['image'])): ?><p><img src="uploads/<?= htmlspecialchars($listing_info['image']) ?>" alt="Listing image" style="max-width:200px"></p><?php endif; ?>
     </div>

--- a/update-request.php
+++ b/update-request.php
@@ -18,6 +18,7 @@ $make = htmlspecialchars(trim($_POST['make'] ?? ''), ENT_QUOTES, 'UTF-8');
 $model = htmlspecialchars(trim($_POST['model'] ?? ''), ENT_QUOTES, 'UTF-8');
 $device_type = htmlspecialchars(trim($_POST['device_type'] ?? ''), ENT_QUOTES, 'UTF-8');
 $issue = htmlspecialchars(trim($_POST['issue'] ?? ''), ENT_QUOTES, 'UTF-8');
+$serial = htmlspecialchars(trim($_POST['serial'] ?? ''), ENT_QUOTES, 'UTF-8');
 $filename = null;
 
 if (!$id || $make === '' || $model === '' || $device_type === '' || $issue === '') {
@@ -43,9 +44,9 @@ if (!empty($_FILES['photo']['name'])) {
   }
 }
 
-$stmt = $conn->prepare("UPDATE service_requests SET make=?, model=?, device_type=?, issue=?, photo=IFNULL(?, photo) WHERE id=? AND user_id=? AND type='trade' AND status IN ('New','Pending')");
+$stmt = $conn->prepare("UPDATE service_requests SET make=?, model=?, device_type=?, issue=?, serial=NULLIF(?, ''), photo=IFNULL(?, photo) WHERE id=? AND user_id=? AND type='trade' AND status IN ('New','Pending')");
 if ($stmt) {
-  $stmt->bind_param("sssssii", $make, $model, $device_type, $issue, $filename, $id, $user_id);
+  $stmt->bind_param("ssssssii", $make, $model, $device_type, $issue, $serial, $filename, $id, $user_id);
   $stmt->execute();
   $stmt->close();
 }


### PR DESCRIPTION
## Summary
- extend listings and trade listings to persist optional brand/model references tied to service brand/model catalogs
- update buyer/trade browsing flows, APIs, and templates to filter and surface the new device metadata
- wire brand/model selection through seller intake tools, trade listing flows, and manager dashboards for creation and maintenance
- seed core phone, console, PC, and component brand/model pairs and add an admin maintenance screen so the taxonomy can be managed without SQL

## Testing
- php -l admin/service-taxonomy.php
- php -l admin/index.php
- php -l api/models.php
- php -l submit-request.php

------
https://chatgpt.com/codex/tasks/task_e_68da10a8b244832b8beededc1b61f42d