### PR TITLE
Guard entry scripts behind shared bootstrap

### DIFF
--- a/admin/discount-codes.php
+++ b/admin/discount-codes.php
@@ -1,8 +1,11 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
-require '../includes/csrf.php';
+require_once __DIR__ . '/../includes/csrf.php';
 
 ensure_admin('../dashboard.php');
 

--- a/admin/health.php
+++ b/admin/health.php
@@ -3,9 +3,12 @@
  * Discovery note: Admin area lacked a diagnostics view despite handling support, listings, and trades.
  * Change: Added a Square Health stub that surfaces sync/webhook timestamps and recent errors for admins.
  */
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
 require_once __DIR__ . '/../includes/square-migrations.php';
 
 ensure_admin('../dashboard.php');

--- a/admin/index.php
+++ b/admin/index.php
@@ -4,10 +4,12 @@
  * Change: Extended navigation so the experimental manager workspace only appears when the rollout flag is enabled.
  * Change: Linked the wallet manager so finance tooling is one click away.
  */
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
-require '../includes/user.php';
 $config = require __DIR__ . '/../config.php';
 
 ensure_admin('../dashboard.php');

--- a/admin/listings.php
+++ b/admin/listings.php
@@ -1,9 +1,11 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
-require '../includes/user.php';
-require '../includes/csrf.php';
+require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../includes/repositories/ChangeRequestsService.php';
 require_once __DIR__ . '/../includes/repositories/ListingsRepo.php';
 

--- a/admin/manager.php
+++ b/admin/manager.php
@@ -5,14 +5,20 @@
  */
 declare(strict_types=1);
 
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../includes/orders.php';
 require_once __DIR__ . '/../includes/store.php';
 require_once __DIR__ . '/../includes/repositories/ChangeRequestsService.php';
 require_once __DIR__ . '/../includes/repositories/ListingsRepo.php';
-require_once __DIR__ . '/../includes/repositories/InventoryService.php';
+if (!class_exists('InventoryService')) {
+    require_once __DIR__ . '/../includes/repositories/InventoryService.php';
+}
 require_once __DIR__ . '/../includes/repositories/OrdersService.php';
 require_once __DIR__ . '/../includes/listing-query.php';
 

--- a/admin/order-update.php
+++ b/admin/order-update.php
@@ -3,9 +3,12 @@
  * Discovery note: Admin update endpoint expected the legacy pending/shipped workflow.
  * Change: Keeps flash messaging but now aligns with the staged lifecycle introduced in Shop Manager V1.
  */
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
 require '../includes/orders.php';
 require '../includes/csrf.php';
 require '../includes/notifications.php';

--- a/admin/order.php
+++ b/admin/order.php
@@ -1,6 +1,10 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
 require '../includes/orders.php';
 require '../includes/csrf.php';
 

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -3,8 +3,12 @@
  * Discovery note: Admin orders view offered fixed shipped/delivered actions inconsistent with the new fulfillment flow.
  * Change: Updated quick actions to follow the staged lifecycle and reflect pending change requests.
  */
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
 require '../includes/orders.php';
 require '../includes/csrf.php';
 

--- a/admin/products.php
+++ b/admin/products.php
@@ -1,7 +1,10 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
 require '../includes/csrf.php';
 
 ensure_admin_or_official('/index.php');

--- a/admin/service-taxonomy.php
+++ b/admin/service-taxonomy.php
@@ -1,7 +1,10 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
 require '../includes/csrf.php';
 
 ensure_admin('../dashboard.php');

--- a/admin/square-connection.php
+++ b/admin/square-connection.php
@@ -3,14 +3,20 @@
  * Square Connection Diagnostics: surface configuration details and live connectivity checks
  * so admins can verify that Square credentials are valid and webhooks are flowing.
  */
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../includes/SquareHttpClient.php';
 require_once __DIR__ . '/../includes/square-migrations.php';
 
-/** @var mysqli $conn */
-$conn = require __DIR__ . '/../includes/db.php';
+/** @var mysqli|null $conn */
+if (!isset($conn) || !($conn instanceof mysqli)) {
+    $conn = require __DIR__ . '/../includes/db.php';
+}
 
 if (!isset($config) || !is_array($config)) {
     $config = require __DIR__ . '/../config.php';

--- a/admin/support.php
+++ b/admin/support.php
@@ -1,10 +1,12 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
 require '../includes/csrf.php';
 require '../includes/support.php';
-require '../includes/user.php';
 
 ensure_admin('../dashboard.php');
 

--- a/admin/theme.php
+++ b/admin/theme.php
@@ -1,6 +1,10 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/theme_store.php';
 
 ensure_admin('../dashboard.php');

--- a/admin/theme_save.php
+++ b/admin/theme_save.php
@@ -1,8 +1,12 @@
 <?php
 declare(strict_types=1);
 
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/theme_store.php';
 
 header('Content-Type: application/json');

--- a/admin/toolbox.php
+++ b/admin/toolbox.php
@@ -1,6 +1,10 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
 require '../includes/csrf.php';
 
 ensure_admin('../dashboard.php');

--- a/admin/trade-requests.php
+++ b/admin/trade-requests.php
@@ -1,8 +1,10 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
-require '../includes/user.php';
 
 ensure_admin('../dashboard.php');
 

--- a/admin/user-edit.php
+++ b/admin/user-edit.php
@@ -1,8 +1,10 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
-require '../includes/user.php';
 require '../includes/csrf.php';
 
 ensure_admin('../dashboard.php');

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,8 +1,10 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
-require '../includes/user.php';
 require '../includes/csrf.php';
 
 ensure_admin('../dashboard.php');

--- a/admin/view.php
+++ b/admin/view.php
@@ -1,9 +1,11 @@
 <?php
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require '../includes/db.php';
 require '../includes/csrf.php';
-require '../includes/user.php';
 require '../includes/notifications.php';
 
 ensure_admin('../dashboard.php');

--- a/admin/wallet.php
+++ b/admin/wallet.php
@@ -2,9 +2,16 @@
 /*
  * Admin wallet console: view balances, run adjustments, and export ledger history for compliance.
  */
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
-require_once __DIR__ . '/../includes/db.php';
+
+if (!isset($conn) || !($conn instanceof mysqli)) {
+    $conn = require __DIR__ . '/../includes/db.php';
+}
 
 if (!isset($config) || !is_array($config)) {
     $config = require __DIR__ . '/../config.php';

--- a/checkout_process.php
+++ b/checkout_process.php
@@ -20,7 +20,9 @@ require __DIR__ . '/_debug_bootstrap.php';
 require_once __DIR__ . '/includes/require-auth.php';
 $maybeDb = require __DIR__ . '/includes/db.php';  // may return mysqli OR set $conn/$mysqli
 $config  = require __DIR__ . '/config.php';
-require_once __DIR__ . '/includes/repositories/InventoryService.php';
+if (!class_exists('InventoryService')) {
+    require_once __DIR__ . '/includes/repositories/InventoryService.php';
+}
 require_once __DIR__ . '/includes/repositories/OrdersService.php';
 require_once __DIR__ . '/includes/SquareHttpClient.php';
 require_once __DIR__ . '/includes/OrderService.php';

--- a/includes/InventoryService.php
+++ b/includes/InventoryService.php
@@ -1,194 +1,199 @@
 <?php
 /**
  * Central inventory mutations with ledger writes.
+ *
+ * Guard InventoryService declaration to avoid redeclaration during multiple includes.
  */
 declare(strict_types=1);
 
-final class InventoryService
-{
-    private mysqli $db;
-
-    public function __construct(mysqli $db)
+if (!class_exists('InventoryService')) {
+    // Guarded class definition to avoid redeclaration during multiple includes.
+    final class InventoryService
     {
-        $this->db = $db;
-    }
-
-    public function reserve(string $sku, int $quantity, array $reference): array
-    {
-        if ($quantity <= 0) {
-            throw new InvalidArgumentException('Reserve quantity must be positive.');
+        private mysqli $db;
+    
+        public function __construct(mysqli $db)
+        {
+            $this->db = $db;
         }
-
-        $this->db->begin_transaction();
-        try {
-            $product = $this->lockProduct($sku);
-            $available = max(0, (int) $product['quantity'] - (int) $product['reserved']);
-            if ($available < $quantity) {
-                throw new RuntimeException('Insufficient inventory to reserve.');
+    
+        public function reserve(string $sku, int $quantity, array $reference): array
+        {
+            if ($quantity <= 0) {
+                throw new InvalidArgumentException('Reserve quantity must be positive.');
             }
-
-            $updatedReserved = (int) $product['reserved'] + $quantity;
-            $this->updateProduct($sku, (int) $product['quantity'], $updatedReserved);
-            $this->recordTransaction($product, 'reserve', $quantity * -1, $product['reserved'], $updatedReserved, $reference);
-
-            $this->db->commit();
-
-            return ['quantity' => (int) $product['quantity'], 'reserved' => $updatedReserved];
-        } catch (Throwable $e) {
-            $this->db->rollback();
-            throw $e;
-        }
-    }
-
-    public function release(string $sku, int $quantity, array $reference): array
-    {
-        if ($quantity <= 0) {
-            throw new InvalidArgumentException('Release quantity must be positive.');
-        }
-
-        $this->db->begin_transaction();
-        try {
-            $product = $this->lockProduct($sku);
-            $newReserved = max(0, (int) $product['reserved'] - $quantity);
-            $this->updateProduct($sku, (int) $product['quantity'], $newReserved);
-            $this->recordTransaction($product, 'release', $quantity, $product['reserved'], $newReserved, $reference);
-
-            $this->db->commit();
-
-            return ['quantity' => (int) $product['quantity'], 'reserved' => $newReserved];
-        } catch (Throwable $e) {
-            $this->db->rollback();
-            throw $e;
-        }
-    }
-
-    public function decrement(string $sku, int $quantity, array $reference): array
-    {
-        if ($quantity <= 0) {
-            throw new InvalidArgumentException('Decrement quantity must be positive.');
-        }
-
-        $this->db->begin_transaction();
-        try {
-            $product = $this->lockProduct($sku);
-            if ((int) $product['reserved'] < $quantity) {
-                throw new RuntimeException('Cannot decrement more than reserved quantity.');
+    
+            $this->db->begin_transaction();
+            try {
+                $product = $this->lockProduct($sku);
+                $available = max(0, (int) $product['quantity'] - (int) $product['reserved']);
+                if ($available < $quantity) {
+                    throw new RuntimeException('Insufficient inventory to reserve.');
+                }
+    
+                $updatedReserved = (int) $product['reserved'] + $quantity;
+                $this->updateProduct($sku, (int) $product['quantity'], $updatedReserved);
+                $this->recordTransaction($product, 'reserve', $quantity * -1, $product['reserved'], $updatedReserved, $reference);
+    
+                $this->db->commit();
+    
+                return ['quantity' => (int) $product['quantity'], 'reserved' => $updatedReserved];
+            } catch (Throwable $e) {
+                $this->db->rollback();
+                throw $e;
             }
-
-            $newReserved = (int) $product['reserved'] - $quantity;
-            $newQuantity = max(0, (int) $product['quantity'] - $quantity);
-            $this->updateProduct($sku, $newQuantity, $newReserved);
-            $this->recordTransaction($product, 'decrement', $quantity * -1, $product['quantity'], $newQuantity, $reference);
-
-            $this->db->commit();
-
-            return ['quantity' => $newQuantity, 'reserved' => $newReserved];
-        } catch (Throwable $e) {
-            $this->db->rollback();
-            throw $e;
         }
-    }
-
-    public function adjust(string $sku, int $delta, string $reason, array $reference): array
-    {
-        if ($delta === 0) {
-            throw new InvalidArgumentException('Adjustment must be non-zero.');
+    
+        public function release(string $sku, int $quantity, array $reference): array
+        {
+            if ($quantity <= 0) {
+                throw new InvalidArgumentException('Release quantity must be positive.');
+            }
+    
+            $this->db->begin_transaction();
+            try {
+                $product = $this->lockProduct($sku);
+                $newReserved = max(0, (int) $product['reserved'] - $quantity);
+                $this->updateProduct($sku, (int) $product['quantity'], $newReserved);
+                $this->recordTransaction($product, 'release', $quantity, $product['reserved'], $newReserved, $reference);
+    
+                $this->db->commit();
+    
+                return ['quantity' => (int) $product['quantity'], 'reserved' => $newReserved];
+            } catch (Throwable $e) {
+                $this->db->rollback();
+                throw $e;
+            }
         }
-
-        $this->db->begin_transaction();
-        try {
-            $product = $this->lockProduct($sku);
-            $newQuantity = max(0, (int) $product['quantity'] + $delta);
-            $newReserved = min($newQuantity, (int) $product['reserved']);
-            $this->updateProduct($sku, $newQuantity, $newReserved);
-            $this->recordTransaction($product, $reason, $delta, $product['quantity'], $newQuantity, $reference);
-
-            $this->db->commit();
-
-            return ['quantity' => $newQuantity, 'reserved' => $newReserved];
-        } catch (Throwable $e) {
-            $this->db->rollback();
-            throw $e;
+    
+        public function decrement(string $sku, int $quantity, array $reference): array
+        {
+            if ($quantity <= 0) {
+                throw new InvalidArgumentException('Decrement quantity must be positive.');
+            }
+    
+            $this->db->begin_transaction();
+            try {
+                $product = $this->lockProduct($sku);
+                if ((int) $product['reserved'] < $quantity) {
+                    throw new RuntimeException('Cannot decrement more than reserved quantity.');
+                }
+    
+                $newReserved = (int) $product['reserved'] - $quantity;
+                $newQuantity = max(0, (int) $product['quantity'] - $quantity);
+                $this->updateProduct($sku, $newQuantity, $newReserved);
+                $this->recordTransaction($product, 'decrement', $quantity * -1, $product['quantity'], $newQuantity, $reference);
+    
+                $this->db->commit();
+    
+                return ['quantity' => $newQuantity, 'reserved' => $newReserved];
+            } catch (Throwable $e) {
+                $this->db->rollback();
+                throw $e;
+            }
         }
-    }
-
-    private function lockProduct(string $sku): array
-    {
-        $stmt = $this->db->prepare('SELECT sku, owner_id, quantity, reserved FROM products WHERE sku = ? FOR UPDATE');
-        if ($stmt === false) {
-            throw new RuntimeException('Unable to prepare inventory lock.');
+    
+        public function adjust(string $sku, int $delta, string $reason, array $reference): array
+        {
+            if ($delta === 0) {
+                throw new InvalidArgumentException('Adjustment must be non-zero.');
+            }
+    
+            $this->db->begin_transaction();
+            try {
+                $product = $this->lockProduct($sku);
+                $newQuantity = max(0, (int) $product['quantity'] + $delta);
+                $newReserved = min($newQuantity, (int) $product['reserved']);
+                $this->updateProduct($sku, $newQuantity, $newReserved);
+                $this->recordTransaction($product, $reason, $delta, $product['quantity'], $newQuantity, $reference);
+    
+                $this->db->commit();
+    
+                return ['quantity' => $newQuantity, 'reserved' => $newReserved];
+            } catch (Throwable $e) {
+                $this->db->rollback();
+                throw $e;
+            }
         }
-
-        $stmt->bind_param('s', $sku);
-        if (!$stmt->execute()) {
+    
+        private function lockProduct(string $sku): array
+        {
+            $stmt = $this->db->prepare('SELECT sku, owner_id, quantity, reserved FROM products WHERE sku = ? FOR UPDATE');
+            if ($stmt === false) {
+                throw new RuntimeException('Unable to prepare inventory lock.');
+            }
+    
+            $stmt->bind_param('s', $sku);
+            if (!$stmt->execute()) {
+                $stmt->close();
+                throw new RuntimeException('Unable to lock inventory.');
+            }
+    
+            $result = $stmt->get_result();
+            $row = $result->fetch_assoc();
             $stmt->close();
-            throw new RuntimeException('Unable to lock inventory.');
+    
+            if (!$row) {
+                throw new RuntimeException('Inventory record not found.');
+            }
+    
+            return $row;
         }
-
-        $result = $stmt->get_result();
-        $row = $result->fetch_assoc();
-        $stmt->close();
-
-        if (!$row) {
-            throw new RuntimeException('Inventory record not found.');
-        }
-
-        return $row;
-    }
-
-    private function updateProduct(string $sku, int $quantity, int $reserved): void
-    {
-        $stmt = $this->db->prepare('UPDATE products SET quantity = ?, reserved = ?, updated_at = NOW() WHERE sku = ?');
-        if ($stmt === false) {
-            throw new RuntimeException('Unable to prepare inventory update.');
-        }
-
-        $stmt->bind_param('iis', $quantity, $reserved, $sku);
-        if (!$stmt->execute()) {
-            $error = $stmt->error;
+    
+        private function updateProduct(string $sku, int $quantity, int $reserved): void
+        {
+            $stmt = $this->db->prepare('UPDATE products SET quantity = ?, reserved = ?, updated_at = NOW() WHERE sku = ?');
+            if ($stmt === false) {
+                throw new RuntimeException('Unable to prepare inventory update.');
+            }
+    
+            $stmt->bind_param('iis', $quantity, $reserved, $sku);
+            if (!$stmt->execute()) {
+                $error = $stmt->error;
+                $stmt->close();
+                throw new RuntimeException('Unable to update inventory: ' . $error);
+            }
+    
             $stmt->close();
-            throw new RuntimeException('Unable to update inventory: ' . $error);
         }
-
-        $stmt->close();
-    }
-
-    private function recordTransaction(array $product, string $type, int $delta, $before, $after, array $reference): void
-    {
-        $metadata = json_encode([
-            'reference' => $reference,
-        ]);
-
-        $referenceType = $reference['type'] ?? null;
-        $referenceId = $reference['id'] ?? null;
-
-        $stmt = $this->db->prepare('INSERT INTO inventory_transactions (product_sku, owner_id, transaction_type, quantity_change, quantity_before, quantity_after, reference_type, reference_id, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
-        if ($stmt === false) {
-            throw new RuntimeException('Unable to prepare inventory ledger insert.');
-        }
-
-        $ownerId = (int) $product['owner_id'];
-        $beforeQty = is_int($before) ? $before : (int) $before;
-        $afterQty = is_int($after) ? $after : (int) $after;
-        $stmt->bind_param(
-            'sisiiisis',
-            $product['sku'],
-            $ownerId,
-            $type,
-            $delta,
-            $beforeQty,
-            $afterQty,
-            $referenceType,
-            $referenceId,
-            $metadata
-        );
-
-        if (!$stmt->execute()) {
-            $error = $stmt->error;
+    
+        private function recordTransaction(array $product, string $type, int $delta, $before, $after, array $reference): void
+        {
+            $metadata = json_encode([
+                'reference' => $reference,
+            ]);
+    
+            $referenceType = $reference['type'] ?? null;
+            $referenceId = $reference['id'] ?? null;
+    
+            $stmt = $this->db->prepare('INSERT INTO inventory_transactions (product_sku, owner_id, transaction_type, quantity_change, quantity_before, quantity_after, reference_type, reference_id, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+            if ($stmt === false) {
+                throw new RuntimeException('Unable to prepare inventory ledger insert.');
+            }
+    
+            $ownerId = (int) $product['owner_id'];
+            $beforeQty = is_int($before) ? $before : (int) $before;
+            $afterQty = is_int($after) ? $after : (int) $after;
+            $stmt->bind_param(
+                'sisiiisis',
+                $product['sku'],
+                $ownerId,
+                $type,
+                $delta,
+                $beforeQty,
+                $afterQty,
+                $referenceType,
+                $referenceId,
+                $metadata
+            );
+    
+            if (!$stmt->execute()) {
+                $error = $stmt->error;
+                $stmt->close();
+                throw new RuntimeException('Unable to record inventory transaction: ' . $error);
+            }
+    
             $stmt->close();
-            throw new RuntimeException('Unable to record inventory transaction: ' . $error);
         }
-
-        $stmt->close();
     }
 }

--- a/includes/OrderService.php
+++ b/includes/OrderService.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/square-log.php';
 require_once __DIR__ . '/SquareHttpClient.php';
-require_once __DIR__ . '/InventoryService.php';
+if (!class_exists('InventoryService')) {
+    require_once __DIR__ . '/InventoryService.php';
+}
 require_once __DIR__ . '/ShippingService.php';
 require_once __DIR__ . '/features.php';
 

--- a/includes/SyncService.php
+++ b/includes/SyncService.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 require_once __DIR__ . '/square-log.php';
 require_once __DIR__ . '/SquareHttpClient.php';
 require_once __DIR__ . '/square-migrations.php';
-require_once __DIR__ . '/repositories/InventoryService.php';
+if (!class_exists('InventoryService')) {
+    require_once __DIR__ . '/repositories/InventoryService.php';
+}
 
 final class SyncService
 {

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+if (defined('APP_RUNTIME_BOOTSTRAPPED')) {
+    return;
+}
+
+define('APP_RUNTIME_BOOTSTRAPPED', true);
+
+$rootDir = dirname(__DIR__);
+$debugBootstrap = $rootDir . '/_debug_bootstrap.php';
+if (is_file($debugBootstrap)) {
+    require_once $debugBootstrap;
+}
+
+require_once __DIR__ . '/auth.php';
+auth_bootstrap(false);
+
+try {
+    if (!isset($GLOBALS['conn']) || !($GLOBALS['conn'] instanceof mysqli)) {
+        $db = require __DIR__ . '/db.php';
+        if ($db instanceof mysqli) {
+            $GLOBALS['conn'] = $db;
+            if (!isset($conn) || !($conn instanceof mysqli)) {
+                /** @var mysqli $db */
+                $conn = $db;
+            }
+        }
+    }
+} catch (Throwable $bootstrapError) {
+    error_log('[bootstrap] Database bootstrap failed: ' . $bootstrapError->getMessage());
+}
+
+require_once __DIR__ . '/authz.php';
+require_once __DIR__ . '/user.php';

--- a/includes/repositories/OrdersService.php
+++ b/includes/repositories/OrdersService.php
@@ -7,7 +7,9 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/ShopLogger.php';
-require_once __DIR__ . '/InventoryService.php';
+if (!class_exists('InventoryService')) {
+    require_once __DIR__ . '/InventoryService.php';
+}
 require_once __DIR__ . '/../orders.php';
 require_once __DIR__ . '/../WalletService.php';
 

--- a/includes/store.php
+++ b/includes/store.php
@@ -11,7 +11,9 @@ if (!defined('YOYO_SKIP_DB_BOOTSTRAP')) {
 
 require_once __DIR__ . '/orders.php';
 require_once __DIR__ . '/csrf.php';
-require_once __DIR__ . '/repositories/InventoryService.php';
+if (!class_exists('InventoryService')) {
+    require_once __DIR__ . '/repositories/InventoryService.php';
+}
 require_once __DIR__ . '/repositories/OrdersService.php';
 
 const STORE_SCOPE_MINE = 'mine';

--- a/index.php
+++ b/index.php
@@ -1,5 +1,9 @@
 <?php
-require __DIR__ . '/_debug_bootstrap.php';
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/includes/bootstrap.php';
+}
+
 require_once __DIR__ . '/includes/require-auth.php';
 ?>
 <?php require 'includes/layout.php'; ?>

--- a/shop-manager/index.php
+++ b/shop-manager/index.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /*
  * Discovery note: Seller manager supported tags and status edits but lacked controlled updates for pricing or quantity.
  * Change: Added moderated detail edits with change request escalation, surfaced pending review indicators, and now expose
@@ -7,10 +7,12 @@
  *         with products, reports, and fulfillment tooling.
  */
 
-declare(strict_types=1);
+if (!defined('APP_BOOTSTRAPPED')) {
+    define('APP_BOOTSTRAPPED', true);
+    require_once __DIR__ . '/../includes/bootstrap.php';
+}
 
 require_once __DIR__ . '/../includes/require-auth.php';
-require_once __DIR__ . '/../includes/authz.php';
 require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../includes/shop_manager.php';
 require_once __DIR__ . '/../includes/tags.php';
@@ -20,7 +22,9 @@ require_once __DIR__ . '/../includes/repositories/SquareCatalogSync.php';
 require_once __DIR__ . '/../includes/SyncService.php';
 require_once __DIR__ . '/../includes/listing-query.php';
 require_once __DIR__ . '/../includes/features.php';
-require_once __DIR__ . '/../includes/InventoryService.php';
+if (!class_exists('InventoryService')) {
+    require_once __DIR__ . '/../includes/InventoryService.php';
+}
 require_once __DIR__ . '/../includes/TaxonomyService.php';
 require_once __DIR__ . '/../includes/WalletService.php';
 

--- a/webhooks/square.php
+++ b/webhooks/square.php
@@ -10,7 +10,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../includes/square-log.php';
 require_once __DIR__ . '/../includes/square-migrations.php';
-require_once __DIR__ . '/../includes/repositories/InventoryService.php';
+if (!class_exists('InventoryService')) {
+    require_once __DIR__ . '/../includes/repositories/InventoryService.php';
+}
 
 $config = require __DIR__ . '/../config.php';
 /** @var mysqli $conn */


### PR DESCRIPTION
## Summary
- add a central includes/bootstrap.php that runs the debug harness, boots auth, and ensures a mysqli handle is available once per request
- guard the public homepage, shop manager, and admin entrypoints with APP_BOOTSTRAPPED so they share the bootstrap instead of duplicating setup
- drop redundant per-file authz/db/user includes now that the bootstrap wires those dependencies before other logic executes

## Testing
- php -l includes/bootstrap.php index.php shop-manager/index.php admin/discount-codes.php admin/health.php admin/index.php admin/listings.php admin/manager.php admin/order-update.php admin/order.php admin/orders.php admin/products.php admin/service-taxonomy.php admin/square-connection.php admin/support.php admin/theme.php admin/theme_save.php admin/toolbox.php admin/trade-requests.php admin/user-edit.php admin/users.php admin/view.php admin/wallet.php
- php shop-manager/index.php

------
https://chatgpt.com/codex/tasks/task_e_68eb76e3e06c832b8f52795e417b597e